### PR TITLE
Prevent cron error by not processing submissions belonging to deleted assignments

### DIFF
--- a/classes/setup_form.class.php
+++ b/classes/setup_form.class.php
@@ -190,7 +190,7 @@ class plagiarism_turnitinsim_setup_form extends moodleform {
 
         // If we don't then retrieve them and overwrite mtrace so it doesn't output to screen.
         $CFG->mtrace_wrapper = 'plagiarism_turnitinsim_mtrace';
-        if (empty($features)) {
+        if (empty($features) || $features = "{}") {
             try {
                 $tstask = new plagiarism_turnitinsim_task();
                 $tstask->check_enabled_features();
@@ -206,26 +206,29 @@ class plagiarism_turnitinsim_setup_form extends moodleform {
 
         // Display Search Repositories.
         $repolist = html_writer::tag('dt', get_string('turnitinfeatures::repositories', 'plagiarism_turnitinsim'));
-        foreach ($features['similarity']['generation_settings']['search_repositories'] as $repo) {
-            $repolist .= html_writer::tag('dd', ucwords(strtolower(str_replace('_', ' ', $repo))));
-        }
-        $enabledfeatures .= html_writer::tag('dl', $repolist, array('class' => 'turnitinsim_featurelist'));
 
-        // Display View Options.
-        $settinglist = html_writer::tag('dt', get_string('turnitinfeatures::viewoptions', 'plagiarism_turnitinsim'));
-        foreach ($features['similarity']['view_settings'] as $setting => $enabled) {
-            $icon = ($enabled) ? 'option-yes' : 'option-no';
-            $icon = $OUTPUT->pix_icon($icon, '', 'plagiarism_turnitinsim', array('class' => 'turnitinsim_optionicon'));
-            $settinglist .= html_writer::tag('dd', $icon.ucwords(str_replace('_', ' ', $setting)));
-        }
-        $enabledfeatures .= html_writer::tag('dl', $settinglist, array('class' => 'turnitinsim_featurelist'));
+        if (!empty($features)) {
+            foreach ($features['similarity']['generation_settings']['search_repositories'] as $repo) {
+                $repolist .= html_writer::tag('dd', ucwords(strtolower(str_replace('_', ' ', $repo))));
+            }
+            $enabledfeatures .= html_writer::tag('dl', $repolist, array('class' => 'turnitinsim_featurelist'));
 
-        $eulastring = (!(bool)$features['tenant']['require_eula']) ? 'eulanotrequired' : 'eularequired';
-        $enabledfeatures .= html_writer::tag(
-            'p',
-            get_string('turnitinfeatures::'.$eulastring, 'plagiarism_turnitinsim'),
-            array('class' => 'bold')
-        );
+            // Display View Options.
+            $settinglist = html_writer::tag('dt', get_string('turnitinfeatures::viewoptions', 'plagiarism_turnitinsim'));
+            foreach ($features['similarity']['view_settings'] as $setting => $enabled) {
+                $icon = ($enabled) ? 'option-yes' : 'option-no';
+                $icon = $OUTPUT->pix_icon($icon, '', 'plagiarism_turnitinsim', array('class' => 'turnitinsim_optionicon'));
+                $settinglist .= html_writer::tag('dd', $icon . ucwords(str_replace('_', ' ', $setting)));
+            }
+            $enabledfeatures .= html_writer::tag('dl', $settinglist, array('class' => 'turnitinsim_featurelist'));
+
+            $eulastring = (!(bool)$features['tenant']['require_eula']) ? 'eulanotrequired' : 'eularequired';
+            $enabledfeatures .= html_writer::tag(
+                'p',
+                get_string('turnitinfeatures::'.$eulastring, 'plagiarism_turnitinsim'),
+                array('class' => 'bold')
+            );
+        }
 
         $enabledfeatures .= html_writer::tag('p', get_string('turnitinfeatures::moreinfo', 'plagiarism_turnitinsim'));
 

--- a/classes/setup_form.class.php
+++ b/classes/setup_form.class.php
@@ -208,27 +208,26 @@ class plagiarism_turnitinsim_setup_form extends moodleform {
         $repolist = html_writer::tag('dt', get_string('turnitinfeatures::repositories', 'plagiarism_turnitinsim'));
 
         if (!empty($features) && $features != "{}") {
-                foreach ($features['similarity']['generation_settings']['search_repositories'] as $repo) {
-                    $repolist .= html_writer::tag('dd', ucwords(strtolower(str_replace('_', ' ', $repo))));
-                }
-                $enabledfeatures .= html_writer::tag('dl', $repolist, array('class' => 'turnitinsim_featurelist'));
-
-                // Display View Options.
-                $settinglist = html_writer::tag('dt', get_string('turnitinfeatures::viewoptions', 'plagiarism_turnitinsim'));
-                foreach ($features['similarity']['view_settings'] as $setting => $enabled) {
-                    $icon = ($enabled) ? 'option-yes' : 'option-no';
-                    $icon = $OUTPUT->pix_icon($icon, '', 'plagiarism_turnitinsim', array('class' => 'turnitinsim_optionicon'));
-                    $settinglist .= html_writer::tag('dd', $icon . ucwords(str_replace('_', ' ', $setting)));
-                }
-                $enabledfeatures .= html_writer::tag('dl', $settinglist, array('class' => 'turnitinsim_featurelist'));
-
-                $eulastring = (!(bool)$features['tenant']['require_eula']) ? 'eulanotrequired' : 'eularequired';
-                $enabledfeatures .= html_writer::tag(
-                    'p',
-                    get_string('turnitinfeatures::'.$eulastring, 'plagiarism_turnitinsim'),
-                    array('class' => 'bold')
-                );
+            foreach ($features['similarity']['generation_settings']['search_repositories'] as $repo) {
+                $repolist .= html_writer::tag('dd', ucwords(strtolower(str_replace('_', ' ', $repo))));
             }
+            $enabledfeatures .= html_writer::tag('dl', $repolist, array('class' => 'turnitinsim_featurelist'));
+
+            // Display View Options.
+            $settinglist = html_writer::tag('dt', get_string('turnitinfeatures::viewoptions', 'plagiarism_turnitinsim'));
+            foreach ($features['similarity']['view_settings'] as $setting => $enabled) {
+                $icon = ($enabled) ? 'option-yes' : 'option-no';
+                $icon = $OUTPUT->pix_icon($icon, '', 'plagiarism_turnitinsim', array('class' => 'turnitinsim_optionicon'));
+                $settinglist .= html_writer::tag('dd', $icon . ucwords(str_replace('_', ' ', $setting)));
+            }
+            $enabledfeatures .= html_writer::tag('dl', $settinglist, array('class' => 'turnitinsim_featurelist'));
+
+            $eulastring = (!(bool)$features['tenant']['require_eula']) ? 'eulanotrequired' : 'eularequired';
+            $enabledfeatures .= html_writer::tag(
+                'p',
+                get_string('turnitinfeatures::'.$eulastring, 'plagiarism_turnitinsim'),
+                array('class' => 'bold')
+            );
         }
 
         $enabledfeatures .= html_writer::tag('p', get_string('turnitinfeatures::moreinfo', 'plagiarism_turnitinsim'));

--- a/classes/setup_form.class.php
+++ b/classes/setup_form.class.php
@@ -207,7 +207,6 @@ class plagiarism_turnitinsim_setup_form extends moodleform {
         // Display Search Repositories.
         $repolist = html_writer::tag('dt', get_string('turnitinfeatures::repositories', 'plagiarism_turnitinsim'));
 
-//        if (!empty($features)) {
         if (!empty($features) && $features != "{}") {
                 foreach ($features['similarity']['generation_settings']['search_repositories'] as $repo) {
                     $repolist .= html_writer::tag('dd', ucwords(strtolower(str_replace('_', ' ', $repo))));

--- a/classes/setup_form.class.php
+++ b/classes/setup_form.class.php
@@ -190,7 +190,7 @@ class plagiarism_turnitinsim_setup_form extends moodleform {
 
         // If we don't then retrieve them and overwrite mtrace so it doesn't output to screen.
         $CFG->mtrace_wrapper = 'plagiarism_turnitinsim_mtrace';
-        if (empty($features) || $features = "{}") {
+        if (empty($features) || $features == "{}") {
             try {
                 $tstask = new plagiarism_turnitinsim_task();
                 $tstask->check_enabled_features();
@@ -207,27 +207,29 @@ class plagiarism_turnitinsim_setup_form extends moodleform {
         // Display Search Repositories.
         $repolist = html_writer::tag('dt', get_string('turnitinfeatures::repositories', 'plagiarism_turnitinsim'));
 
-        if (!empty($features)) {
-            foreach ($features['similarity']['generation_settings']['search_repositories'] as $repo) {
-                $repolist .= html_writer::tag('dd', ucwords(strtolower(str_replace('_', ' ', $repo))));
-            }
-            $enabledfeatures .= html_writer::tag('dl', $repolist, array('class' => 'turnitinsim_featurelist'));
+//        if (!empty($features)) {
+        if (!empty($features) && $features != "{}") {
+                foreach ($features['similarity']['generation_settings']['search_repositories'] as $repo) {
+                    $repolist .= html_writer::tag('dd', ucwords(strtolower(str_replace('_', ' ', $repo))));
+                }
+                $enabledfeatures .= html_writer::tag('dl', $repolist, array('class' => 'turnitinsim_featurelist'));
 
-            // Display View Options.
-            $settinglist = html_writer::tag('dt', get_string('turnitinfeatures::viewoptions', 'plagiarism_turnitinsim'));
-            foreach ($features['similarity']['view_settings'] as $setting => $enabled) {
-                $icon = ($enabled) ? 'option-yes' : 'option-no';
-                $icon = $OUTPUT->pix_icon($icon, '', 'plagiarism_turnitinsim', array('class' => 'turnitinsim_optionicon'));
-                $settinglist .= html_writer::tag('dd', $icon . ucwords(str_replace('_', ' ', $setting)));
-            }
-            $enabledfeatures .= html_writer::tag('dl', $settinglist, array('class' => 'turnitinsim_featurelist'));
+                // Display View Options.
+                $settinglist = html_writer::tag('dt', get_string('turnitinfeatures::viewoptions', 'plagiarism_turnitinsim'));
+                foreach ($features['similarity']['view_settings'] as $setting => $enabled) {
+                    $icon = ($enabled) ? 'option-yes' : 'option-no';
+                    $icon = $OUTPUT->pix_icon($icon, '', 'plagiarism_turnitinsim', array('class' => 'turnitinsim_optionicon'));
+                    $settinglist .= html_writer::tag('dd', $icon . ucwords(str_replace('_', ' ', $setting)));
+                }
+                $enabledfeatures .= html_writer::tag('dl', $settinglist, array('class' => 'turnitinsim_featurelist'));
 
-            $eulastring = (!(bool)$features['tenant']['require_eula']) ? 'eulanotrequired' : 'eularequired';
-            $enabledfeatures .= html_writer::tag(
-                'p',
-                get_string('turnitinfeatures::'.$eulastring, 'plagiarism_turnitinsim'),
-                array('class' => 'bold')
-            );
+                $eulastring = (!(bool)$features['tenant']['require_eula']) ? 'eulanotrequired' : 'eularequired';
+                $enabledfeatures .= html_writer::tag(
+                    'p',
+                    get_string('turnitinfeatures::'.$eulastring, 'plagiarism_turnitinsim'),
+                    array('class' => 'bold')
+                );
+            }
         }
 
         $enabledfeatures .= html_writer::tag('p', get_string('turnitinfeatures::moreinfo', 'plagiarism_turnitinsim'));

--- a/classes/submission.class.php
+++ b/classes/submission.class.php
@@ -101,6 +101,13 @@ class plagiarism_turnitinsim_submission {
      */
     public function calculate_generation_time($generated = false) {
         $cm = get_coursemodule_from_id('', $this->getcm());
+
+        // If we can't find a course module, don't proceed.
+        if (!$cm) {
+            $this->settogenerate(0);
+            return;
+        }
+
         $plagiarismsettings = $this->plagiarism_plugin_turnitinsim->get_settings($cm->id);
 
         // Create module object.

--- a/classes/task.class.php
+++ b/classes/task.class.php
@@ -68,6 +68,7 @@ class plagiarism_turnitinsim_task {
         }
 
         // Get Submissions to send.
+        // Joined with course_modules so that we don't send queued submissions for submissions belonging to deleted course_modules.
         $submissions = $DB->get_records_sql('SELECT s.id FROM {plagiarism_turnitinsim_sub} s
                                     JOIN {course_modules} c
                                     ON s.cm = c.id
@@ -125,10 +126,6 @@ class plagiarism_turnitinsim_task {
                                         AND turnitinid IS NOT NULL',
             array(1, time(), TURNITINSIM_SUBMISSION_STATUS_REQUESTED, 0)
         );
-
-        echo '<pre>';
-        var_dump($submissions);
-        echo '</pre>';
 
         // Request reports be generated or get scores for reports that have been requested.
         $count = 0;

--- a/classes/task.class.php
+++ b/classes/task.class.php
@@ -120,7 +120,6 @@ class plagiarism_turnitinsim_task {
         // Request reports be generated or get scores for reports that have been requested.
         $count = 0;
         foreach ($submissions as $submission) {
-
             $tssubmission = new plagiarism_turnitinsim_submission($this->tsrequest, $submission->id);
 
             // Request Originality Report to be generated if it hasn't already, this should have been done by the


### PR DESCRIPTION
I've modified the queries for the cron tasks so that we no longer process submissions that belong to assignments that no longer exist. This was causing a fatal error in the cron if unprocessed submissions existed for deleted assignments.

I've also modified the calculate_generation_time() method so that if we get in here and a course module ($cm) can't be found the code will not error out.

Fixed a couple of minor issues as well. When setting up the plugin, if features object is empty then warnings would be displayed on the page, fixed with a simple isset() check. Also fixed an issue whereby if $features was a string containing an empty object {} the plugin wouldn't attempt to get them again because empty() wouldn't see it as empty.