### PR TITLE
Fix for processing of deleted submissions - no longer errors in cron

### DIFF
--- a/classes/submission.class.php
+++ b/classes/submission.class.php
@@ -498,6 +498,16 @@ class plagiarism_turnitinsim_submission {
         // Create request body with file attached.
         if ($this->type == "file") {
             $filedetails = $this->get_file_details();
+
+            // Check that the file exists and is not empty.
+            if (!$filedetails) {
+                $this->setstatus(TURNITINSIM_SUBMISSION_STATUS_EMPTY_DELETED);
+                $this->settiiattempts(TURNITINSIM_SUBMISSION_MAX_SEND_ATTEMPTS);
+                $this->update();
+
+                return;
+            }
+
             // Encode filename.
             $filename = str_replace('%20', ' ', rawurlencode($filedetails->get_filename()));
 


### PR DESCRIPTION
Fix for processing of deleted submissions.

This fixes an issue where a deleted file would cause a fatal error in the cron after editing a submission and removing the file.