### PR TITLE
Reprocess submissions where the file did not upload and a score was requested

### DIFF
--- a/classes/submission.class.php
+++ b/classes/submission.class.php
@@ -462,7 +462,6 @@ class plagiarism_turnitinsim_submission {
                 // Handle a TURNITINSIM_HTTP_CREATED response.
                 $this->setturnitinid($params->id);
                 $this->setstatus($params->status);
-                $this->settiiattempts(0);
                 $this->setsubmittedtime(strtotime($params->created_time));
 
                 mtrace(get_string('taskoutputsubmissioncreated', 'plagiarism_turnitinsim', $params->id));
@@ -726,12 +725,16 @@ class plagiarism_turnitinsim_submission {
 
                 switch ($response->status) {
                     case TURNITINSIM_SUBMISSION_STATUS_CREATED:
-                        // Submission has been created but no file has been uploaded. Don't allow retry.
-                        $this->setstatus(TURNITINSIM_SUBMISSION_STATUS_ERROR);
-                        $this->settiiattempts(TURNITINSIM_REPORT_GEN_MAX_ATTEMPTS);
+                        // Submission has been created but no file has been uploaded. Reprocess and allow retry in an hour.
+                        $this->setstatus(TURNITINSIM_SUBMISSION_STATUS_QUEUED);
+                        $this->settiiattempts($this->gettiiattempts() + 1);
+                        $this->settiiretrytime(time() + ($this->gettiiattempts() * TURNITINSIM_REPORT_GEN_RETRY_WAIT_SECONDS));
 
                         // Error message should come from the call for the report.
-                        $this->seterrormessage($params->message);
+                        if ($this->gettiiattempts() == 3) {
+                            $this->setstatus(TURNITINSIM_SUBMISSION_STATUS_ERROR);
+                            $this->seterrormessage($params->message);
+                        }
 
                         break;
                     case TURNITINSIM_SUBMISSION_STATUS_ERROR:
@@ -750,6 +753,10 @@ class plagiarism_turnitinsim_submission {
                         $this->settiiattempts($this->gettiiattempts() + 1);
                         $this->settiiretrytime(time() + ($this->gettiiattempts() * TURNITINSIM_REPORT_GEN_RETRY_WAIT_SECONDS));
 
+                        if ($this->gettiiattempts() == 3) {
+                            $this->setstatus(TURNITINSIM_SUBMISSION_STATUS_ERROR);
+                            $this->seterrormessage(get_string('submissiondisplaystatus:unknown', 'plagiarism_turnitinsim'));
+                        }
                         break;
                 }
 

--- a/classes/submission.class.php
+++ b/classes/submission.class.php
@@ -731,7 +731,7 @@ class plagiarism_turnitinsim_submission {
                         $this->settiiretrytime(time() + ($this->gettiiattempts() * TURNITINSIM_REPORT_GEN_RETRY_WAIT_SECONDS));
 
                         // Error message should come from the call for the report.
-                        if ($this->gettiiattempts() == 3) {
+                        if ($this->gettiiattempts() == TURNITINSIM_REPORT_GEN_MAX_ATTEMPTS) {
                             $this->setstatus(TURNITINSIM_SUBMISSION_STATUS_ERROR);
                             $this->seterrormessage($params->message);
                         }
@@ -753,7 +753,7 @@ class plagiarism_turnitinsim_submission {
                         $this->settiiattempts($this->gettiiattempts() + 1);
                         $this->settiiretrytime(time() + ($this->gettiiattempts() * TURNITINSIM_REPORT_GEN_RETRY_WAIT_SECONDS));
 
-                        if ($this->gettiiattempts() == 3) {
+                        if ($this->gettiiattempts() == TURNITINSIM_REPORT_GEN_MAX_ATTEMPTS) {
                             $this->setstatus(TURNITINSIM_SUBMISSION_STATUS_ERROR);
                             $this->seterrormessage(get_string('submissiondisplaystatus:unknown', 'plagiarism_turnitinsim'));
                         }

--- a/tests/classes/tssubmission_test.php
+++ b/tests/classes/tssubmission_test.php
@@ -1763,12 +1763,12 @@ class plagiarism_turnitinsim_submission_class_testcase extends advanced_testcase
 
         $this->assertEquals(TURNITINSIM_SUBMISSION_STATUS_QUEUED, $record->status);
         $this->assertEquals(1, $record->tiiattempts);
-        $this->assertEquals(0, $record->tiiretrytime);
         $this->assertEquals('', $record->errormessage);
+        $this->assertGreaterThan(time(), $record->tiiretrytime);
 
         // Prepare to test scenario where max attempts is reached.
         $tssubmission->setstatus(TURNITINSIM_SUBMISSION_STATUS_CREATED);
-        $tssubmission->settiiattempts(2);
+        $tssubmission->settiiattempts(TURNITINSIM_REPORT_GEN_MAX_ATTEMPTS - 1);
         $tssubmission->update();
 
         $tssubmission->handle_similarity_response($params);
@@ -1866,7 +1866,7 @@ class plagiarism_turnitinsim_submission_class_testcase extends advanced_testcase
         $this->assertGreaterThan(time(), $record->tiiretrytime);
 
         // Prepare to test scenario where max attempts is reached.
-        $tssubmission->settiiattempts(2);
+        $tssubmission->settiiattempts(TURNITINSIM_REPORT_GEN_MAX_ATTEMPTS - 1);
         $tssubmission->update();
 
         $tssubmission->handle_similarity_response($params);


### PR DESCRIPTION
Reprocess submissions where the file did not upload and a score was requested.

Instead of setting submissions straight to error and not retrying, submissions will now be requeued so that the plugin can process them again and attempt to upload the file again.

This will only happen a maximum of 3 times to avoid the plugin getting into a loop.