### PR TITLE
Set defaults for messaging for EULA message so that it does not email by default

### DIFF
--- a/db/install.php
+++ b/db/install.php
@@ -25,6 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
+require_once($CFG->dirroot . '/plagiarism/turnitinsim/lib.php');
+
 /**
  * Configuration to update on install.
  */

--- a/db/messages.php
+++ b/db/messages.php
@@ -37,5 +37,10 @@ $messageproviders = array (
         'capability'  => 'moodle/site:config'
     ),
     // Notify all Turnitin users with a link to accept the new EULA.
-    'new_eula' => array ()
+    'new_eula' => array (
+        'defaults' => [
+            'popup' => MESSAGE_PERMITTED,
+            'email' => MESSAGE_PERMITTED
+        ],
+    )
 );

--- a/db/uninstall.php
+++ b/db/uninstall.php
@@ -25,6 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
+require_once($CFG->dirroot . '/plagiarism/turnitinsim/lib.php');
+
 /**
  * Configuration to remove on install.
  */

--- a/tests/utilities/handle_deprecation_test.php
+++ b/tests/utilities/handle_deprecation_test.php
@@ -65,6 +65,8 @@ class plagiarism_turnitinsim_handle_deprecation_testcase extends advanced_testca
     public function test_unset_turnitinsim_use_unsets_value_in_39() {
         $this->resetAfterTest();
 
+        set_config('branch', 39);
+
         set_config( 'turnitinsim_use', 1, 'plagiarism');
 
         (new handle_deprecation)->unset_turnitinsim_use();


### PR DESCRIPTION
Set defaults for messaging for EULA message so that it does not email by default.

Also included some necessities that should have been in #51 as uninstall was failing.

The MESSAGE_PERMITTED constant means that a user can enable the functionality. As per the API docs at https://docs.moodle.org/dev/Message_API#Setting_defaults