### PR TITLE
Fix for handling of deleted activities

### DIFF
--- a/classes/submission.class.php
+++ b/classes/submission.class.php
@@ -1398,7 +1398,7 @@ class plagiarism_turnitinsim_submission {
      * @param string $error Error code from Turnitin.
      * @param int $retryattempts Maximum retry attempts.
      */
-    private function set_error_with_max_retry_attempts($error, $retryattempts) {
+    public function set_error_with_max_retry_attempts($error, $retryattempts) {
         $this->settiiattempts($retryattempts);
         $this->seterrormessage($error);
         $this->setstatus(TURNITINSIM_SUBMISSION_STATUS_ERROR);

--- a/lang/en/plagiarism_turnitinsim.php
+++ b/lang/en/plagiarism_turnitinsim.php
@@ -194,3 +194,4 @@ $string['privacy:metadata:plagiarism_turnitinsim_client:submission_content'] = '
 
 $string['errorenabledfeatures'] = 'Could not get the list of enabled features.';
 $string['errorgettingsubmissioninfo'] = 'There was an error attempting to get the submission info.';
+$string['errorprocessingdeletedsubmission'] = 'This submission belongs to a deleted assignment and cannot be processed.';


### PR DESCRIPTION
Fixes an issue where the cron would repeatedly try to process queued submissions that belong to deleted assignments, as the deleted assignments can stay in soft deletion for quite a while - causing a cron blockage if there are more than 50 of them. This fix sets the queued submissions to an error status so that they won't be processed again.