### PR TITLE
Updating English help link

### DIFF
--- a/classes/settings.class.php
+++ b/classes/settings.class.php
@@ -140,7 +140,7 @@ class plagiarism_turnitinsim_settings {
 
         // Show link to guides.
         $link = html_writer::link(
-            get_string('helplink', 'plagiarism_turnitinsim'),
+            get_string('help_link', 'plagiarism_turnitinsim'),
             get_string('settingslearnmore', 'plagiarism_turnitinsim'),
             array('target' => '_blank')
         );

--- a/classes/settings.class.php
+++ b/classes/settings.class.php
@@ -140,7 +140,7 @@ class plagiarism_turnitinsim_settings {
 
         // Show link to guides.
         $link = html_writer::link(
-            TURNITINSIM_HELP_LINK,
+            get_string('helplink', 'plagiarism_turnitinsim'),
             get_string('settingslearnmore', 'plagiarism_turnitinsim'),
             array('target' => '_blank')
         );

--- a/lang/da/plagiarism_turnitinsim.php
+++ b/lang/da/plagiarism_turnitinsim.php
@@ -1,0 +1,28 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Strings for plagiarism_turnitinsim component, language: Danish.
+ *
+ * This file should only contain *_link strings as other strings are handling through AMOS.
+ *
+ * @package   plagiarism_turnitinsim
+ * @copyright 2017 Turnitin
+ * @author    David Winn <dwinn@turnitin.com>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+$string['help_link'] = 'https://help.turnitin.com/da/integrity/administrator/moodle.htm#step-four';

--- a/lang/da/plagiarism_turnitinsim.php
+++ b/lang/da/plagiarism_turnitinsim.php
@@ -20,7 +20,7 @@
  * This file should only contain *_link strings as other strings are handling through AMOS.
  *
  * @package   plagiarism_turnitinsim
- * @copyright 2017 Turnitin
+ * @copyright 2020 Turnitin
  * @author    David Winn <dwinn@turnitin.com>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */

--- a/lang/de/plagiarism_turnitinsim.php
+++ b/lang/de/plagiarism_turnitinsim.php
@@ -20,7 +20,7 @@
  * This file should only contain *_link strings as other strings are handling through AMOS.
  *
  * @package   plagiarism_turnitinsim
- * @copyright 2017 Turnitin
+ * @copyright 2020 Turnitin
  * @author    David Winn <dwinn@turnitin.com>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */

--- a/lang/de/plagiarism_turnitinsim.php
+++ b/lang/de/plagiarism_turnitinsim.php
@@ -1,0 +1,28 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Strings for plagiarism_turnitinsim component, language: German.
+ *
+ * This file should only contain *_link strings as other strings are handling through AMOS.
+ *
+ * @package   plagiarism_turnitinsim
+ * @copyright 2017 Turnitin
+ * @author    David Winn <dwinn@turnitin.com>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+$string['help_link'] = 'https://help.turnitin.com/de/integrity/administratoren/verwenden-von-turnitin-mit-moodle.htm#step-four';

--- a/lang/en/plagiarism_turnitinsim.php
+++ b/lang/en/plagiarism_turnitinsim.php
@@ -196,4 +196,4 @@ $string['privacy:metadata:plagiarism_turnitinsim_client:submission_content'] = '
 $string['errorenabledfeatures'] = 'Could not get the list of enabled features.';
 $string['errorgettingsubmissioninfo'] = 'There was an error attempting to get the submission info.';
 $string['errorprocessingdeletedsubmission'] = 'This submission belongs to a deleted assignment and cannot be processed.';
-$string['helplink'] = 'https://help.turnitin.com/integrity/administrator/moodle.htm#step-four';
+$string['help_link'] = 'https://help.turnitin.com/integrity/administrator/moodle.htm#step-four';

--- a/lang/en/plagiarism_turnitinsim.php
+++ b/lang/en/plagiarism_turnitinsim.php
@@ -18,7 +18,7 @@
  * Strings for plagiarism_turnitinsim component, language 'en'
  *
  * @package   plagiarism_turnitinsim
- * @copyright 2017 Turnitin
+ * @copyright 2020 Turnitin
  * @author    John McGettrick <jmcgettrick@turnitin.com>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */

--- a/lang/en/plagiarism_turnitinsim.php
+++ b/lang/en/plagiarism_turnitinsim.php
@@ -196,3 +196,4 @@ $string['privacy:metadata:plagiarism_turnitinsim_client:submission_content'] = '
 $string['errorenabledfeatures'] = 'Could not get the list of enabled features.';
 $string['errorgettingsubmissioninfo'] = 'There was an error attempting to get the submission info.';
 $string['errorprocessingdeletedsubmission'] = 'This submission belongs to a deleted assignment and cannot be processed.';
+$string['helplink'] = 'https://help.turnitin.com/integrity/administrator/moodle.htm#step-four';

--- a/lang/es_mx/plagiarism_turnitinsim.php
+++ b/lang/es_mx/plagiarism_turnitinsim.php
@@ -1,0 +1,28 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Strings for plagiarism_turnitinsim component, language: Mexican Spanish.
+ *
+ * This file should only contain *_link strings as other strings are handling through AMOS.
+ *
+ * @package   plagiarism_turnitinsim
+ * @copyright 2017 Turnitin
+ * @author    David Winn <dwinn@turnitin.com>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+$string['help_link'] = 'https://help.turnitin.com/es/integrity/administrador/moodle.htm#step-four';

--- a/lang/es_mx/plagiarism_turnitinsim.php
+++ b/lang/es_mx/plagiarism_turnitinsim.php
@@ -20,7 +20,7 @@
  * This file should only contain *_link strings as other strings are handling through AMOS.
  *
  * @package   plagiarism_turnitinsim
- * @copyright 2017 Turnitin
+ * @copyright 2020 Turnitin
  * @author    David Winn <dwinn@turnitin.com>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */

--- a/lang/fr/plagiarism_turnitinsim.php
+++ b/lang/fr/plagiarism_turnitinsim.php
@@ -1,0 +1,28 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Strings for plagiarism_turnitinsim component, language: French.
+ *
+ * This file should only contain *_link strings as other strings are handling through AMOS.
+ *
+ * @package   plagiarism_turnitinsim
+ * @copyright 2017 Turnitin
+ * @author    David Winn <dwinn@turnitin.com>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+$string['help_link'] = 'https://help.turnitin.com/fr/integrity/administrateur/moodle.htm#step-four';

--- a/lang/fr/plagiarism_turnitinsim.php
+++ b/lang/fr/plagiarism_turnitinsim.php
@@ -20,7 +20,7 @@
  * This file should only contain *_link strings as other strings are handling through AMOS.
  *
  * @package   plagiarism_turnitinsim
- * @copyright 2017 Turnitin
+ * @copyright 2020 Turnitin
  * @author    David Winn <dwinn@turnitin.com>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */

--- a/lang/nl/plagiarism_turnitinsim.php
+++ b/lang/nl/plagiarism_turnitinsim.php
@@ -1,0 +1,28 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Strings for plagiarism_turnitinsim component, language: Dutch.
+ *
+ * This file should only contain *_link strings as other strings are handling through AMOS.
+ *
+ * @package   plagiarism_turnitinsim
+ * @copyright 2017 Turnitin
+ * @author    David Winn <dwinn@turnitin.com>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+$string['help_link'] = 'https://help.turnitin.com/nl/integrity/beheerder/moodle.htm#step-four';

--- a/lang/nl/plagiarism_turnitinsim.php
+++ b/lang/nl/plagiarism_turnitinsim.php
@@ -20,7 +20,7 @@
  * This file should only contain *_link strings as other strings are handling through AMOS.
  *
  * @package   plagiarism_turnitinsim
- * @copyright 2017 Turnitin
+ * @copyright 2020 Turnitin
  * @author    David Winn <dwinn@turnitin.com>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */

--- a/lang/no/plagiarism_turnitinsim.php
+++ b/lang/no/plagiarism_turnitinsim.php
@@ -20,7 +20,7 @@
  * This file should only contain *_link strings as other strings are handling through AMOS.
  *
  * @package   plagiarism_turnitinsim
- * @copyright 2017 Turnitin
+ * @copyright 2020 Turnitin
  * @author    David Winn <dwinn@turnitin.com>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */

--- a/lang/no/plagiarism_turnitinsim.php
+++ b/lang/no/plagiarism_turnitinsim.php
@@ -1,0 +1,28 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Strings for plagiarism_turnitinsim component, language: Norwegian.
+ *
+ * This file should only contain *_link strings as other strings are handling through AMOS.
+ *
+ * @package   plagiarism_turnitinsim
+ * @copyright 2017 Turnitin
+ * @author    David Winn <dwinn@turnitin.com>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+$string['help_link'] = 'https://help.turnitin.com/nb/integrity/administrer/moodle.htm#step-four';

--- a/lang/pt_br/plagiarism_turnitinsim.php
+++ b/lang/pt_br/plagiarism_turnitinsim.php
@@ -20,7 +20,7 @@
  * This file should only contain *_link strings as other strings are handling through AMOS.
  *
  * @package   plagiarism_turnitinsim
- * @copyright 2017 Turnitin
+ * @copyright 2020 Turnitin
  * @author    David Winn <dwinn@turnitin.com>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */

--- a/lang/pt_br/plagiarism_turnitinsim.php
+++ b/lang/pt_br/plagiarism_turnitinsim.php
@@ -1,0 +1,28 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Strings for plagiarism_turnitinsim component, language: Brazilian Portuguese.
+ *
+ * This file should only contain *_link strings as other strings are handling through AMOS.
+ *
+ * @package   plagiarism_turnitinsim
+ * @copyright 2017 Turnitin
+ * @author    David Winn <dwinn@turnitin.com>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+$string['help_link'] = 'https://help.turnitin.com/pt-br/integrity/administrador/moodle.htm#step-four';

--- a/lang/sv/plagiarism_turnitinsim.php
+++ b/lang/sv/plagiarism_turnitinsim.php
@@ -1,0 +1,28 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Strings for plagiarism_turnitinsim component, language: Swedish.
+ *
+ * This file should only contain *_link strings as other strings are handling through AMOS.
+ *
+ * @package   plagiarism_turnitinsim
+ * @copyright 2017 Turnitin
+ * @author    David Winn <dwinn@turnitin.com>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+$string['help_link'] = 'https://help.turnitin.com/sv/integrity/administrator/moodle.htm#step-four';

--- a/lang/sv/plagiarism_turnitinsim.php
+++ b/lang/sv/plagiarism_turnitinsim.php
@@ -20,7 +20,7 @@
  * This file should only contain *_link strings as other strings are handling through AMOS.
  *
  * @package   plagiarism_turnitinsim
- * @copyright 2017 Turnitin
+ * @copyright 2020 Turnitin
  * @author    David Winn <dwinn@turnitin.com>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */

--- a/utilities/constants.php
+++ b/utilities/constants.php
@@ -69,7 +69,6 @@ define('TURNITINSIM_ENDPOINT_GET_FEATURES_ENABLED', '/v1/features-enabled');
 define('TURNITINSIM_ENDPOINT_LOGGING', '/remote-logging/api/log');
 
 // URLs.
-define('TURNITINSIM_HELP_LINK', 'https://help.turnitin.com/simcheck/integrations/moodle/moodle-home.htm');
 define('TURNITINSIM_EULA', '/plagiarism/turnitinsim/eula.php?cmd=displayeula');
 define('TURNITINSIM_CALLBACK_URL', $CFG->wwwroot.'/plagiarism/turnitinsim/callbacks.php');
 


### PR DESCRIPTION
I had to remove the constant for the help link so that we can differentiate between the languages we support. Alternative would be to formulate the URL with code but then we'd have to maintain an array of supported languages. Doing it this way allows us to add URLs for new languages to Moodle's AMOS system without requiring a release.