### PR TITLE
Fix permissions for display of plugin settings

### DIFF
--- a/classes/settings.class.php
+++ b/classes/settings.class.php
@@ -49,12 +49,13 @@ class plagiarism_turnitinsim_settings {
      * Add Turnitin settings to module form.
      *
      * @param object $mform The Moodle form object.
+     * @param boolean $canconfigureplugin If this user has permission to configure the plugin.
      * @param string $context The context, eg module or course.
      * @param string $modulename The name of the module.
      * @return mixed Moodle form with settings.
      * @throws coding_exception
      */
-    public function add_settings_to_module($mform, $context = 'module', $modulename = '') {
+    public function add_settings_to_module($mform, $canconfigureplugin = false, $context = 'module', $modulename = '') {
         global $PAGE;
 
         if ($context == 'module') {
@@ -145,6 +146,15 @@ class plagiarism_turnitinsim_settings {
             array('target' => '_blank')
         );
         $mform->addElement('html', html_writer::tag('div', $link));
+
+        if (!$canconfigureplugin) {
+            $mform->freeze('turnitinenabled');
+            $mform->freeze('excludeoptions');
+            $mform->freeze('indexoptions');
+            $mform->freeze('reportgenoptions');
+            $mform->freeze('accessoptions');
+            $mform->freeze('queuedrafts');
+        }
 
         return $mform;
     }

--- a/lib.php
+++ b/lib.php
@@ -78,7 +78,7 @@ class plagiarism_plugin_turnitinsim extends plagiarism_plugin {
 
         if ($location === 'module') {
             // Exit if Turnitin is not being used for this activity type and location is not default.
-            if ($moduletiienabled === "0") {
+            if (empty($moduletiienabled)) {
                 return;
             }
 

--- a/lib.php
+++ b/lib.php
@@ -60,6 +60,9 @@ class plagiarism_plugin_turnitinsim extends plagiarism_plugin {
     public function get_form_elements_module($mform, $context, $modulename = "") {
         // This is a bit of a hack and untidy way to ensure the form elements aren't displayed twice.
         // TODO: Remove once this method is removed.
+
+        $canconfigureplugin = false;
+
         static $hassettings;
         if ($hassettings) {
             return;
@@ -73,13 +76,26 @@ class plagiarism_plugin_turnitinsim extends plagiarism_plugin {
         $moduletiienabled = empty($modulename) ? "0" : get_config('plagiarism_turnitinsim',
             'turnitinmodenabled'.substr($modulename, 4));
 
-        // Exit if Turnitin is not being used for this activity type and location is not default.
-        if ($location === 'module' && $moduletiienabled === "0") {
-            return;
+        if ($location === 'module') {
+            // Exit if Turnitin is not being used for this activity type and location is not default.
+            if ($moduletiienabled === "0") {
+                return;
+            }
+
+            // Course ID is only passed in on new module - if updating then get it from module id.
+            $courseid = optional_param('course', 0, PARAM_INT);
+            if (empty($courseid)) {
+                $courseid = get_coursemodule_from_id('', $cmid)->course;
+            }
+
+            // Exit if this user does not have permissions to configure the plugin.
+            if (has_capability('plagiarism/turnitinsim:enable', context_module::instance($courseid))) {
+                $canconfigureplugin = true;
+            }
         }
 
         $form = new plagiarism_turnitinsim_settings();
-        $form->add_settings_to_module($mform, $location, $modulename);
+        $form->add_settings_to_module($mform, $canconfigureplugin, $location, $modulename);
 
         if ($modsettings = $this->get_settings( $cmid )) {
 


### PR DESCRIPTION
Fixes the issue where you could set permissions for being able to configure the plugin but it was not actually being used.
Also fixes the issue where plugin settings would appear for activities which we don't support.