### PR TITLE
INT-14332: Fix for spacing between radio buttons in settings

### DIFF
--- a/classes/settings.class.php
+++ b/classes/settings.class.php
@@ -100,16 +100,36 @@ class plagiarism_turnitinsim_settings {
 
             // Immediate.
             $label = get_string('reportgen0', 'plagiarism_turnitinsim');
-            $reportgen[] = $mform->createElement('radio', 'reportgeneration', null, $label, TURNITINSIM_REPORT_GEN_IMMEDIATE);
+            $reportgen[] = $mform->createElement(
+                'radio', 
+                'reportgeneration', 
+                null, 
+                $label, 
+                TURNITINSIM_REPORT_GEN_IMMEDIATE, 
+                array('class' => 'turnitinsim_settings_radio')
+            );
 
             // Immediate and Due Date.
             $label = get_string('reportgen1', 'plagiarism_turnitinsim');
-            $reportgen[] = $mform->createElement('radio', 'reportgeneration', null, $label,
-            TURNITINSIM_REPORT_GEN_IMMEDIATE_AND_DUEDATE);
+            $reportgen[] = $mform->createElement(
+                'radio', 
+                'reportgeneration', 
+                null, 
+                $label,
+                TURNITINSIM_REPORT_GEN_IMMEDIATE_AND_DUEDATE,
+                array('class' => 'turnitinsim_settings_radio')
+            );
 
             // Due Date.
             $label = get_string('reportgen2', 'plagiarism_turnitinsim');
-            $reportgen[] = $mform->createElement('radio', 'reportgeneration', null, $label, TURNITINSIM_REPORT_GEN_DUEDATE);
+            $reportgen[] = $mform->createElement(
+                'radio', 
+                'reportgeneration', 
+                null, 
+                $label, 
+                TURNITINSIM_REPORT_GEN_DUEDATE, 
+                array('class' => 'turnitinsim_settings_radio')
+            );
 
             // Group Report Gen options together.
             $mform->addGroup($reportgen, 'reportgenoptions', get_string('reportgenoptions', 'plagiarism_turnitinsim'), '<br />');

--- a/styles.css
+++ b/styles.css
@@ -128,6 +128,6 @@
     color: #fff;
 }
 
-.turnitinsim_settings_radio {
+.form-group .form-inline .form-check-inline.form-check-label.fitem.turnitinsim_settings_radio {
     margin-right: 0;
 }

--- a/styles.css
+++ b/styles.css
@@ -127,3 +127,7 @@
     background: #db4221;
     color: #fff;
 }
+
+.turnitinsim_settings_radio {
+    margin-right: 0;
+}


### PR DESCRIPTION
All but the first radio button are given a width of 100%, but then are also given a margin-right value. And at least in some browsers the margin isn’t considered when using 100%, so it is 100% + margin-right value, which makes it line wrap and puts a line height between the radio buttons.

The solution is to set the margin-right value on our specific radio buttons to 0 to prevent the width going beyond the allowed horizontal space.