### PR TITLE
Correct unit test file/class names

### DIFF
--- a/tests/classes/assign.class_test.php
+++ b/tests/classes/assign.class_test.php
@@ -32,7 +32,7 @@ require_once($CFG->dirroot . '/plagiarism/turnitinsim/tests/utilities.php');
 /**
  * Tests for assign module class for plagiarism_turnitinsim component.
  */
-class assign_test extends advanced_testcase {
+class assign_class_testcase extends advanced_testcase {
 
     /**
      * This is text content for unit testing a text submission.

--- a/tests/classes/callback.class_test.php
+++ b/tests/classes/callback.class_test.php
@@ -34,7 +34,7 @@ require_once($CFG->dirroot . '/plagiarism/turnitinsim/tests/utilities.php');
 /**
  * Tests for Turnitin Integrity submission class.
  */
-class plagiarism_tscallback_class_testcase extends advanced_testcase {
+class callback_class_testcase extends advanced_testcase {
 
     /**
      * Set config for use in the tests.

--- a/tests/classes/defaults_form_class_test.php
+++ b/tests/classes/defaults_form_class_test.php
@@ -31,7 +31,7 @@ require_once($CFG->dirroot . '/plagiarism/turnitinsim/classes/defaults_form.clas
 /**
  * Tests for default settings form.
  */
-class plagiarism_tsdefaultsform_testcase extends advanced_testcase {
+class defaultsform_class_testcase extends advanced_testcase {
 
     /**
      * Set config for use in the tests.

--- a/tests/classes/eula.class_test.php
+++ b/tests/classes/eula.class_test.php
@@ -32,7 +32,7 @@ require_once($CFG->dirroot . '/plagiarism/turnitinsim/tests/utilities.php');
 /**
  * Tests for Turnitin Integrity submission class.
  */
-class plagiarism_turnitinsim_eula_class_testcase extends advanced_testcase {
+class eula_class_testcase extends advanced_testcase {
 
     /**
      * Set config for use in the tests.

--- a/tests/classes/forum.class_test.php
+++ b/tests/classes/forum.class_test.php
@@ -32,7 +32,7 @@ require_once($CFG->dirroot . '/plagiarism/turnitinsim/tests/utilities.php');
 /**
  * Tests for forum module class for plagiarism_turnitinsim component.
  */
-class forum_test extends advanced_testcase {
+class forum_class_testcase extends advanced_testcase {
 
     /**
      * Sample text for testing a forum.

--- a/tests/classes/group.class_test.php
+++ b/tests/classes/group.class_test.php
@@ -31,7 +31,7 @@ require_once($CFG->dirroot . '/plagiarism/turnitinsim/classes/group.class.php');
 /**
  * Tests for Turnitin Integrity group class.
  */
-class plagiarism_turnitinsim_group_class_testcase extends advanced_testcase {
+class group_class_testcase extends advanced_testcase {
 
     /**
      * Test that group constructor creates a turnitinid in the correct format.

--- a/tests/classes/logging_request_class_test.php
+++ b/tests/classes/logging_request_class_test.php
@@ -32,7 +32,7 @@ require_once($CFG->dirroot . '/plagiarism/turnitinsim/tests/utilities.php');
 /**
  * Tests for Turnitin Integrity submission class.
  */
-class plagiarism_turnitinsim_logging_request_class_testcase extends advanced_testcase {
+class logging_request_class_testcase extends advanced_testcase {
 
 
     /**

--- a/tests/classes/quiz.class_test.php
+++ b/tests/classes/quiz.class_test.php
@@ -34,7 +34,7 @@ require_once($CFG->dirroot . '/mod/workshop/tests/fixtures/testable.php');
 /**
  * Tests for quiz module class for plagiarism_turnitinsim component
  */
-class quiz_test extends advanced_testcase {
+class quiz_class_testcase extends advanced_testcase {
 
     /**
      * Sample text used for unit testing a quiz.

--- a/tests/classes/request_class_test.php
+++ b/tests/classes/request_class_test.php
@@ -33,7 +33,7 @@ require_once($CFG->dirroot . '/plagiarism/turnitinsim/tests/utilities.php');
 /**
  * Tests for Turnitin Integrity submission class.
  */
-class plagiarism_tsrequest_testcase extends advanced_testcase {
+class request_class_testcase extends advanced_testcase {
 
     /**
      * Set config for use in the tests.

--- a/tests/classes/settings_class_test.php
+++ b/tests/classes/settings_class_test.php
@@ -32,7 +32,7 @@ require_once($CFG->dirroot . '/plagiarism/turnitinsim/classes/settings.class.php
 /**
  * Tests for settings form.
  */
-class plagiarism_tssettings_class_testcase extends advanced_testcase {
+class settings_class_testcase extends advanced_testcase {
 
     /**
      * Set config for use in the tests.

--- a/tests/classes/setup_form_class_test.php
+++ b/tests/classes/setup_form_class_test.php
@@ -31,7 +31,7 @@ require_once($CFG->dirroot . '/plagiarism/turnitinsim/classes/setup_form.class.p
 /**
  * Tests for settings form.
  */
-class plagiarism_tssetupform_class_testcase extends advanced_testcase {
+class setupform_class_testcase extends advanced_testcase {
 
     /**
      * Plugin enabled.

--- a/tests/classes/submission_class_test.php
+++ b/tests/classes/submission_class_test.php
@@ -32,7 +32,7 @@ require_once($CFG->dirroot . '/plagiarism/turnitinsim/tests/utilities.php');
 /**
  * Tests for Turnitin Integrity submission class.
  */
-class plagiarism_turnitinsim_submission_class_testcase extends advanced_testcase {
+class submission_class_testcase extends advanced_testcase {
 
     /**
      * A valid submission ID.

--- a/tests/classes/task_class_test.php
+++ b/tests/classes/task_class_test.php
@@ -31,7 +31,7 @@ require_once($CFG->dirroot . '/plagiarism/turnitinsim/classes/task.class.php');
 /**
  * Tests for Turnitin Integrity user class.
  */
-class plagiarism_turnitinsim_task_class_testcase extends advanced_testcase {
+class task_class_testcase extends advanced_testcase {
 
     /**
      * An example API URL used for unit testing.

--- a/tests/classes/user_class_test.php
+++ b/tests/classes/user_class_test.php
@@ -31,7 +31,7 @@ require_once($CFG->dirroot . '/plagiarism/turnitinsim/classes/user.class.php');
 /**
  * Tests for Turnitin Integrity user class.
  */
-class plagiarism_turnitinsim_user_class_testcase extends advanced_testcase {
+class user_class_testcase extends advanced_testcase {
 
     /**
      * Test that user constructor creates a turnitinid in the correct format.

--- a/tests/classes/workshop_class_test.php
+++ b/tests/classes/workshop_class_test.php
@@ -34,7 +34,7 @@ require_once($CFG->dirroot . '/mod/workshop/tests/fixtures/testable.php');
 /**
  * Tests for workshop module class for plagiarism_turnitinsim component
  */
-class workshop_test extends advanced_testcase {
+class workshop_class_testcase extends advanced_testcase {
 
     /**
      * Sample text used for unit testing a workshop.


### PR DESCRIPTION
This pull request corrects unit test file/class names as per Moodle guidelines and for consistency - IE a unit test file name should match that of the file being tested, with _test appended.