### PR TITLE
Fix handle_exception method to use third parameter

### DIFF
--- a/classes/request.class.php
+++ b/classes/request.class.php
@@ -281,11 +281,13 @@ class plagiarism_turnitinsim_request {
      *
      * @param object $e The exception.
      * @param string $displaystr The string to display for the error.
+     * @param string|object|array $a An object, string or number that can be used
+     *      within translation strings
      * @throws coding_exception
      */
-    public function handle_exception($e, $displaystr = '') {
+    public function handle_exception($e, $displaystr = '', $a = null) {
 
-        $errorstr = get_string($displaystr, 'plagiarism_turnitinsim').PHP_EOL;
+        $errorstr = get_string($displaystr, 'plagiarism_turnitinsim', $a).PHP_EOL;
 
         if (is_callable(array($e, 'getFaultCode'))) {
             $errorstr .= get_string('faultcode', 'plagiarism_turnitinsim').": ".$e->getFaultCode().PHP_EOL;

--- a/classes/settings.class.php
+++ b/classes/settings.class.php
@@ -101,20 +101,20 @@ class plagiarism_turnitinsim_settings {
             // Immediate.
             $label = get_string('reportgen0', 'plagiarism_turnitinsim');
             $reportgen[] = $mform->createElement(
-                'radio', 
-                'reportgeneration', 
-                null, 
-                $label, 
-                TURNITINSIM_REPORT_GEN_IMMEDIATE, 
+                'radio',
+                'reportgeneration',
+                null,
+                $label,
+                TURNITINSIM_REPORT_GEN_IMMEDIATE,
                 array('class' => 'turnitinsim_settings_radio')
             );
 
             // Immediate and Due Date.
             $label = get_string('reportgen1', 'plagiarism_turnitinsim');
             $reportgen[] = $mform->createElement(
-                'radio', 
-                'reportgeneration', 
-                null, 
+                'radio',
+                'reportgeneration',
+                null,
                 $label,
                 TURNITINSIM_REPORT_GEN_IMMEDIATE_AND_DUEDATE,
                 array('class' => 'turnitinsim_settings_radio')
@@ -123,11 +123,11 @@ class plagiarism_turnitinsim_settings {
             // Due Date.
             $label = get_string('reportgen2', 'plagiarism_turnitinsim');
             $reportgen[] = $mform->createElement(
-                'radio', 
-                'reportgeneration', 
-                null, 
-                $label, 
-                TURNITINSIM_REPORT_GEN_DUEDATE, 
+                'radio',
+                'reportgeneration',
+                null,
+                $label,
+                TURNITINSIM_REPORT_GEN_DUEDATE,
                 array('class' => 'turnitinsim_settings_radio')
             );
 

--- a/classes/submission.class.php
+++ b/classes/submission.class.php
@@ -597,7 +597,6 @@ class plagiarism_turnitinsim_submission {
             // Handle response from the API.
             $this->handle_upload_response($responsedata, $filename);
         } catch (Exception $e) {
-
             $this->tsrequest->handle_exception($e, 'taskoutputfailedupload', $this->getturnitinid());
         }
     }


### PR DESCRIPTION
Fix handle_exception method to use third parameter.
There is also some trailing space removal in the settings file, trailing spaces usually aren't liked by Moodle code style checkers.