### PR TITLE
Updating the unit tests to work in Moodle 3.10.

### DIFF
--- a/tests/classes/assign.class_test.php
+++ b/tests/classes/assign.class_test.php
@@ -42,7 +42,7 @@ class assign_class_testcase extends advanced_testcase {
     /**
      * Set config for use in the tests.
      */
-    public function setup() {
+    public function setUp(): void {
         global $DB;
 
         // Set plugin as enabled in config for this module type.

--- a/tests/classes/callback.class_test.php
+++ b/tests/classes/callback.class_test.php
@@ -39,7 +39,7 @@ class callback_class_testcase extends advanced_testcase {
     /**
      * Set config for use in the tests.
      */
-    public function setup() {
+    public function setUp(): void {
         global $CFG;
 
         // Set plugin as enabled in config for this module type.

--- a/tests/classes/defaults_form_class_test.php
+++ b/tests/classes/defaults_form_class_test.php
@@ -27,6 +27,7 @@ defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
 require_once($CFG->dirroot . '/plagiarism/turnitinsim/classes/defaults_form.class.php');
+require_once($CFG->dirroot . '/plagiarism/turnitinsim/utilities/handle_deprecation.php');
 
 /**
  * Tests for default settings form.
@@ -36,7 +37,7 @@ class defaultsform_class_testcase extends advanced_testcase {
     /**
      * Set config for use in the tests.
      */
-    public function setup() {
+    public function setUp(): void {
         // Set API details in config.
         set_config('turnitinapiurl', 'http://www.example.com', 'plagiarism_turnitinsim');
         set_config('turnitinapikey', 1234, 'plagiarism_turnitinsim');
@@ -87,6 +88,6 @@ class defaultsform_class_testcase extends advanced_testcase {
         $form = new plagiarism_turnitinsim_defaults_form();
         $output = $form->display();
 
-        $this->assertContains('</form>', $output);
+        handle_deprecation::assertContains($this, '</form>', $output);
     }
 }

--- a/tests/classes/eula.class_test.php
+++ b/tests/classes/eula.class_test.php
@@ -37,7 +37,7 @@ class eula_class_testcase extends advanced_testcase {
     /**
      * Set config for use in the tests.
      */
-    public function setup() {
+    public function setUp(): void {
         global $CFG;
 
         // Set plugin as enabled in config for this module type.

--- a/tests/classes/forum.class_test.php
+++ b/tests/classes/forum.class_test.php
@@ -42,7 +42,7 @@ class forum_class_testcase extends advanced_testcase {
     /**
      * Set config for use in the tests.
      */
-    public function setup() {
+    public function setUp(): void {
         global $DB;
 
         // Set plugin as enabled in config for this module type.

--- a/tests/classes/logging_request_class_test.php
+++ b/tests/classes/logging_request_class_test.php
@@ -38,7 +38,7 @@ class logging_request_class_testcase extends advanced_testcase {
     /**
      * Set config for use in the tests.
      */
-    public function setup() {
+    public function setUp(): void {
         // Set plugin as enabled in config for this module type.
         set_config('turnitinenableremotelogging', 1, 'plagiarism_turnitinsim');
         set_config('turnitinenablelogging', 0, 'plagiarism_turnitinsim');

--- a/tests/classes/quiz.class_test.php
+++ b/tests/classes/quiz.class_test.php
@@ -49,7 +49,7 @@ class quiz_class_testcase extends advanced_testcase {
     /**
      * Set config for use in the tests.
      */
-    public function setup() {
+    public function setUp(): void {
         // Set plugin as enabled in config for this module type.
         set_config('turnitinapiurl', 'http://www.example.com', 'plagiarism_turnitinsim');
         set_config('turnitinapikey', 1234, 'plagiarism_turnitinsim');

--- a/tests/classes/request_class_test.php
+++ b/tests/classes/request_class_test.php
@@ -38,7 +38,7 @@ class request_class_testcase extends advanced_testcase {
     /**
      * Set config for use in the tests.
      */
-    public function setup() {
+    public function setUp(): void {
         // Set plugin as enabled in config for this module type.
         set_config('turnitinapiurl', 'http://www.example.com', 'plagiarism_turnitinsim');
         set_config('turnitinapikey', 1234, 'plagiarism_turnitinsim');

--- a/tests/classes/settings_class_test.php
+++ b/tests/classes/settings_class_test.php
@@ -37,7 +37,7 @@ class settings_class_testcase extends advanced_testcase {
     /**
      * Set config for use in the tests.
      */
-    public function setup() {
+    public function setUp(): void {
         global $CFG;
 
         // Set API details in config.

--- a/tests/classes/setup_form_class_test.php
+++ b/tests/classes/setup_form_class_test.php
@@ -27,6 +27,7 @@ defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
 require_once($CFG->dirroot . '/plagiarism/turnitinsim/classes/setup_form.class.php');
+require_once($CFG->dirroot . '/plagiarism/turnitinsim/utilities/handle_deprecation.php');
 
 /**
  * Tests for settings form.
@@ -132,10 +133,10 @@ class setupform_class_testcase extends advanced_testcase {
         $form = new plagiarism_turnitinsim_setup_form();
         $output = $form->display();
 
-        $this->assertContains('</form>', $output);
+        handle_deprecation::assertContains($this, '</form>', $output);
 
         // Verify that FERPA statement is present.
-        $this->assertContains(get_string('viewerpermissionferpa', 'plagiarism_turnitinsim'), $output);
+        handle_deprecation::assertContains($this, get_string('viewerpermissionferpa', 'plagiarism_turnitinsim'), $output);
     }
 
     /**
@@ -170,6 +171,6 @@ class setupform_class_testcase extends advanced_testcase {
         $form = new plagiarism_turnitinsim_setup_form();
         $output = $form->display_features();
 
-        $this->assertContains(get_string('turnitinfeatures::moreinfo', 'plagiarism_turnitinsim'), $output);
+        handle_deprecation::assertContains($this, get_string('turnitinfeatures::moreinfo', 'plagiarism_turnitinsim'), $output);
     }
 }

--- a/tests/classes/submission_class_test.php
+++ b/tests/classes/submission_class_test.php
@@ -28,6 +28,7 @@ defined('MOODLE_INTERNAL') || die();
 global $CFG;
 require_once($CFG->dirroot . '/plagiarism/turnitinsim/lib.php');
 require_once($CFG->dirroot . '/plagiarism/turnitinsim/tests/utilities.php');
+require_once($CFG->dirroot . '/plagiarism/turnitinsim/utilities/handle_deprecation.php');
 
 /**
  * Tests for Turnitin Integrity submission class.
@@ -57,7 +58,7 @@ class submission_class_testcase extends advanced_testcase {
     /**
      * Set config for use in the tests.
      */
-    public function setup() {
+    public function setUp(): void {
         global $CFG, $DB;
 
         // Set plugin as enabled in config for this module type.
@@ -137,7 +138,7 @@ class submission_class_testcase extends advanced_testcase {
         $tssubmission->update();
 
         // Submission id should now be set.
-        $this->assertInternalType("int", $tssubmission->getid());
+        handle_deprecation::assertInternalTypeInt($this, $tssubmission->getid());
 
         // Check an id that doesn't exist doesn't return an object.
         $submission = $DB->get_record('plagiarism_turnitinsim_sub', array('id' => 0));
@@ -252,15 +253,15 @@ class submission_class_testcase extends advanced_testcase {
         $tsuser2 = new plagiarism_turnitinsim_user($this->student2->id);
 
         // Check user array returns correct details.
-        $this->assertContains($this->student1->lastname, $owners[0]['family_name']);
-        $this->assertContains($this->student1->firstname, $owners[0]['given_name']);
-        $this->assertContains($this->student1->email, $owners[0]['email']);
-        $this->assertContains($tsuser1->get_turnitinid(), $owners[0]['id']);
+        handle_deprecation::assertContains($this, $this->student1->lastname, $owners[0]['family_name']);
+        handle_deprecation::assertContains($this, $this->student1->firstname, $owners[0]['given_name']);
+        handle_deprecation::assertContains($this, $this->student1->email, $owners[0]['email']);
+        handle_deprecation::assertContains($this, $tsuser1->get_turnitinid(), $owners[0]['id']);
 
-        $this->assertContains($this->student2->lastname, $owners[1]['family_name']);
-        $this->assertContains($this->student2->firstname, $owners[1]['given_name']);
-        $this->assertContains($this->student2->email, $owners[1]['email']);
-        $this->assertContains($tsuser2->get_turnitinid(), $owners[1]['id']);
+        handle_deprecation::assertContains($this, $this->student2->lastname, $owners[1]['family_name']);
+        handle_deprecation::assertContains($this, $this->student2->firstname, $owners[1]['given_name']);
+        handle_deprecation::assertContains($this, $this->student2->email, $owners[1]['email']);
+        handle_deprecation::assertContains($this, $tsuser2->get_turnitinid(), $owners[1]['id']);
     }
 
     /**

--- a/tests/classes/task_class_test.php
+++ b/tests/classes/task_class_test.php
@@ -46,7 +46,7 @@ class task_class_testcase extends advanced_testcase {
     /**
      * Set config for use in the tests.
      */
-    public function setup() {
+    public function setUp(): void {
         global $CFG;
 
         // Set plugin as enabled in config for this module type.

--- a/tests/classes/workshop_class_test.php
+++ b/tests/classes/workshop_class_test.php
@@ -44,7 +44,7 @@ class workshop_class_testcase extends advanced_testcase {
     /**
      * Set config for use in the tests.
      */
-    public function setup() {
+    public function setUp(): void {
         // Set plugin as enabled in config for this module type.
         set_config('turnitinapiurl', 'http://www.example.com', 'plagiarism_turnitinsim');
         set_config('turnitinapikey', 1234, 'plagiarism_turnitinsim');

--- a/tests/lib_test.php
+++ b/tests/lib_test.php
@@ -28,6 +28,7 @@ defined('MOODLE_INTERNAL') || die();
 global $CFG;
 require_once($CFG->dirroot . '/plagiarism/turnitinsim/lib.php');
 require_once($CFG->dirroot . '/plagiarism/turnitinsim/classes/setup_form.class.php');
+require_once($CFG->dirroot . '/plagiarism/turnitinsim/utilities/handle_deprecation.php');
 
 /**
  * Tests for lib methods.
@@ -68,7 +69,7 @@ class plagiarism_turnitinsim_lib_testcase extends advanced_testcase {
     /**
      * Set config for use in the tests.
      */
-    public function setup() {
+    public function setUp(): void {
         global $DB;
 
         // Set plugin as enabled in config for this module type.
@@ -276,16 +277,16 @@ class plagiarism_turnitinsim_lib_testcase extends advanced_testcase {
         // The HTML returned should contain the queued status and a Tii icon.
         $plagiarismturnitinsim = new plagiarism_plugin_turnitinsim();
 
-        $this->assertContains(
+        handle_deprecation::assertContains($this,
             '<span>'.get_string( 'submissiondisplaystatus:queued', 'plagiarism_turnitinsim').'</span>',
             $plagiarismturnitinsim->get_links($linkarray)
         );
-        $this->assertContains('tii_icon', $plagiarismturnitinsim->get_links($linkarray));
+        handle_deprecation::assertContains($this, 'tii_icon', $plagiarismturnitinsim->get_links($linkarray));
 
         // Change submission status to Uploaded and verify that pending is displayed.
         $tssubmission->setstatus(TURNITINSIM_SUBMISSION_STATUS_UPLOADED);
         $tssubmission->update();
-        $this->assertContains(
+        handle_deprecation::assertContains($this,
             '<span>'.get_string( 'submissiondisplaystatus:pending', 'plagiarism_turnitinsim').'</span>',
             $plagiarismturnitinsim->get_links($linkarray)
         );
@@ -293,7 +294,7 @@ class plagiarism_turnitinsim_lib_testcase extends advanced_testcase {
         // Change submission status to Uploaded and verify that not sent is displayed.
         $tssubmission->setstatus(TURNITINSIM_SUBMISSION_STATUS_NOT_SENT);
         $tssubmission->update();
-        $this->assertContains(
+        handle_deprecation::assertContains($this,
             '<span>'.get_string( 'submissiondisplaystatus:notsent', 'plagiarism_turnitinsim').'</span>',
             $plagiarismturnitinsim->get_links($linkarray)
         );
@@ -301,7 +302,7 @@ class plagiarism_turnitinsim_lib_testcase extends advanced_testcase {
         // Change submission status to Requested and verify that pending is displayed.
         $tssubmission->setstatus(TURNITINSIM_SUBMISSION_STATUS_REQUESTED);
         $tssubmission->update();
-        $this->assertContains(
+        handle_deprecation::assertContains($this,
             '<span>'.get_string( 'submissiondisplaystatus:pending', 'plagiarism_turnitinsim').'</span>',
             $plagiarismturnitinsim->get_links($linkarray)
         );
@@ -311,17 +312,17 @@ class plagiarism_turnitinsim_lib_testcase extends advanced_testcase {
         $tssubmission->update();
         $output = $plagiarismturnitinsim->get_links($linkarray);
 
-        $this->assertContains(
+        handle_deprecation::assertContains($this,
             get_string('submissiondisplaystatus:awaitingeula', 'plagiarism_turnitinsim'),
             $output
         );
-        $this->assertContains(
+        handle_deprecation::assertContains($this,
             get_string('submissiondisplayerror:eulanotaccepted_help', 'plagiarism_turnitinsim'),
             $output
         );
         // Log instructor in and check they do not see a resubmit link.
         $this->setUser($this->instructor);
-        $this->assertNotContains(
+        handle_deprecation::assertNotContains($this,
             get_string('resubmittoturnitin', 'plagiarism_turnitinsim'),
             $output
         );
@@ -329,7 +330,7 @@ class plagiarism_turnitinsim_lib_testcase extends advanced_testcase {
         // Change submission status to a non constant and verify that the default is displayed.
         $tssubmission->setstatus('nonconstantstring');
         $tssubmission->update();
-        $this->assertContains(
+        handle_deprecation::assertContains($this,
             get_string( 'submissiondisplaystatus:unknown', 'plagiarism_turnitinsim'),
             $plagiarismturnitinsim->get_links($linkarray));
 
@@ -337,7 +338,7 @@ class plagiarism_turnitinsim_lib_testcase extends advanced_testcase {
         $tssubmission->setstatus(TURNITINSIM_SUBMISSION_STATUS_ERROR);
         $tssubmission->seterrormessage(TURNITINSIM_SUBMISSION_STATUS_TOO_MUCH_TEXT);
         $tssubmission->update();
-        $this->assertContains(
+        handle_deprecation::assertContains($this,
             get_string( 'submissiondisplayerror:toomuchtext', 'plagiarism_turnitinsim'),
             $plagiarismturnitinsim->get_links($linkarray)
         );
@@ -345,14 +346,14 @@ class plagiarism_turnitinsim_lib_testcase extends advanced_testcase {
         // Change error message to generic and verify that it is displayed.
         $tssubmission->seterrormessage('random_string_that_is_not_a_constant');
         $tssubmission->update();
-        $this->assertContains(
+        handle_deprecation::assertContains($this,
             get_string( 'submissiondisplayerror:generic', 'plagiarism_turnitinsim'),
             $plagiarismturnitinsim->get_links($linkarray)
         );
 
         // Log instructor in and check they see a resubmit link.
         $this->setUser($this->instructor);
-        $this->assertContains(
+        handle_deprecation::assertContains($this,
             get_string( 'resubmittoturnitin', 'plagiarism_turnitinsim'),
             $plagiarismturnitinsim->get_links($linkarray)
         );
@@ -362,8 +363,8 @@ class plagiarism_turnitinsim_lib_testcase extends advanced_testcase {
         $tssubmission->setstatus(TURNITINSIM_SUBMISSION_STATUS_COMPLETE);
         $tssubmission->setoverallscore($score);
         $tssubmission->update();
-        $this->assertContains($score.'%', $plagiarismturnitinsim->get_links($linkarray));
-        $this->assertContains('or_score_colour_' . round($score, -1), $plagiarismturnitinsim->get_links($linkarray));
+        handle_deprecation::assertContains($this, $score.'%', $plagiarismturnitinsim->get_links($linkarray));
+        handle_deprecation::assertContains($this, 'or_score_colour_' . round($score, -1), $plagiarismturnitinsim->get_links($linkarray));
     }
 
     /**
@@ -374,7 +375,7 @@ class plagiarism_turnitinsim_lib_testcase extends advanced_testcase {
 
         $plagiarismturnitinsim = new plagiarism_plugin_turnitinsim();
         $submissionid = 1;
-        $this->assertContains('pp_resubmit_id_'.$submissionid, $plagiarismturnitinsim->render_resubmit_link($submissionid));
+        handle_deprecation::assertContains($this, 'pp_resubmit_id_'.$submissionid, $plagiarismturnitinsim->render_resubmit_link($submissionid));
     }
 
     /**
@@ -489,7 +490,7 @@ class plagiarism_turnitinsim_lib_testcase extends advanced_testcase {
 
         // Verify EULA is output.
         $plagiarismturnitinsim = new plagiarism_plugin_turnitinsim();
-        $this->assertContains(
+        handle_deprecation::assertContains($this,
             get_string('eulalink', 'plagiarism_turnitinsim', $eulaurl),
             $plagiarismturnitinsim->print_disclosure($this->cm->id)
         );
@@ -525,7 +526,7 @@ class plagiarism_turnitinsim_lib_testcase extends advanced_testcase {
 
         // Verify EULA is not output.
         $plagiarismturnitinsim = new plagiarism_plugin_turnitinsim();
-        $this->assertContains(
+        handle_deprecation::assertContains($this,
             get_string('eulaalreadyaccepted', 'plagiarism_turnitinsim'),
             $plagiarismturnitinsim->print_disclosure($this->cm->id));
     }
@@ -557,7 +558,7 @@ class plagiarism_turnitinsim_lib_testcase extends advanced_testcase {
 
         // Verify EULA is not output.
         $plagiarismturnitinsim = new plagiarism_plugin_turnitinsim();
-        $this->assertContains(
+        handle_deprecation::assertContains($this,
             get_string('eulanotrequired', 'plagiarism_turnitinsim'),
             $plagiarismturnitinsim->print_disclosure($this->cm->id));
     }

--- a/tests/privacy/provider_test.php
+++ b/tests/privacy/provider_test.php
@@ -42,7 +42,7 @@ class plagiarism_turnitinsim_privacy_provider_testcase extends advanced_testcase
     /**
      * Setup method that runs before each test.
      */
-    public function setup() {
+    public function setUp(): void {
         $this->turnitinsim_generator = new turnitinsim_generator();
         $this->submission = $this->turnitinsim_generator->create_submission();
     }

--- a/utilities/handle_deprecation.php
+++ b/utilities/handle_deprecation.php
@@ -109,8 +109,54 @@ class handle_deprecation {
      */
     public static function download_data($exportfile, $dataformat, $columns, $data) {
         global $CFG;
-        
-        $CFG->branch >= 39 ? \core\dataformat::download_data($exportfile, $dataformat, $columns, $data) 
+
+        $CFG->branch >= 39 ? \core\dataformat::download_data($exportfile, $dataformat, $columns, $data)
             : download_as_dataformat($exportfile, $dataformat, $columns, $data);
+    }
+
+    /**
+     * In Moodle 3.10, Moodle switched to use PHPUnit 8.5 which contains deprecations for some assertions.
+     * assertContains was deprecated in favour of the newer assertStringContainsString. (PHPUnit 7.5)
+     * This method handles our support for Moodle versions that use PHPUnit 6.5. (Moodle 3.5 and 3.6)
+     *
+     * @param object $object The test class object.
+     * @param string $needle The string we want to find.
+     * @param string $haystack The string we are searching within.
+     */
+    public static function assertContains($object, $needle, $haystack) {
+        global $CFG;
+
+        $CFG->branch >= 37 ? $object->assertStringContainsString($needle, $haystack)
+            : $object->assertContains($needle, $haystack);
+    }
+
+    /**
+     * In Moodle 3.10, Moodle switched to use PHPUnit 8.5 which contains deprecations for some assertions.
+     * assertNotContains was deprecated in favour of the newer assertStringNotContainsString. (PHPUnit 7.5)
+     * This method handles our support for Moodle versions that use PHPUnit 6.5. (Moodle 3.5 and 3.6)
+     *
+     * @param object $object The test class object.
+     * @param string $needle The string we want to find.
+     * @param string $haystack The string we are searching within.
+     */
+    public static function assertNotContains($object, $needle, $haystack) {
+        global $CFG;
+
+        $CFG->branch >= 37 ? $object->assertStringNotContainsString($needle, $haystack)
+            : $object->assertNotContains($needle, $haystack);
+    }
+
+    /**
+     * In Moodle 3.10, Moodle switched to use PHPUnit 8.5 which contains deprecations for some assertions.
+     * assertInternalType was deprecated in favour of newer methods such as assertIsInt. (PHPUnit 7.5)
+     * This method handles our support for Moodle versions that use PHPUnit 6.5. (Moodle 3.5 and 3.6)
+     *
+     * @param object $object The test class object.
+     * @param string $value The value we are looking for.
+     */
+    public static function assertInternalTypeInt($object, $value) {
+        global $CFG;
+
+        $CFG->branch >= 37 ? $object->assertIsInt($value) : $object->assertInternalType("int", $value);
     }
 }


### PR DESCRIPTION
In Moodle 3.10, Moodle switched to use PHPUnit 8.5 which contains deprecations for some assertions. These throw warnings for some tests instead of running those tests, so they needed changing.

As these new assertions were implemented in PHPUnit 7.5 and we support Moodle versions still using 6.5 we had to be able to support both of the assertions. Once we no longer support Moodle 3.5 and 3.6 we can remove this code and just use the new assertions.

PHPUnit also requires the setUp method to declare the return type. This is a PHP7 feature and Moodle 3.5 minimum PHP version is 7.1 so this will be backwards compatible.