### PR TITLE
Don't create mod entry if Turnitin disabled

### DIFF
--- a/classes/settings.class.php
+++ b/classes/settings.class.php
@@ -206,7 +206,10 @@ class plagiarism_turnitinsim_settings {
             $settings->id = $modsettings->id;
             $DB->update_record('plagiarism_turnitinsim_mod', $settings);
         } else {
-            $DB->insert_record('plagiarism_turnitinsim_mod', $settings);
+            // Inserts only happen on activity creation, so if turnitinenabled is false - don't insert.
+            if ($settings->turnitinenabled) {
+                $DB->insert_record('plagiarism_turnitinsim_mod', $settings);
+            }
         }
     }
 

--- a/tests/classes/settings_class_test.php
+++ b/tests/classes/settings_class_test.php
@@ -99,6 +99,27 @@ class settings_class_testcase extends advanced_testcase {
     }
 
     /**
+     * Test that save module settings does not create an entry if Turnitin is disabled.
+     */
+    public function test_save_module_settings_does_not_create_entry_if_turnitin_disabled() {
+        global $DB;
+
+        $this->resetAfterTest();
+
+        // Create data object for new assignment.
+        $data = new stdClass();
+        $data->coursemodule = 1;
+        $data->turnitinenabled = 0;
+
+        // Save Module Settings to test inserting.
+        $form = new plagiarism_turnitinsim_settings();
+        $form->save_module_settings($data);
+
+        // Check that there is no entry for this module.
+        $this->assertFalse($DB->get_record('plagiarism_turnitinsim_mod', array('cm' => $data->coursemodule)));
+    }
+
+    /**
      * Test that get_enabled_features does not return features on failure.
      */
     public function test_get_enabled_features_failure() {


### PR DESCRIPTION
Don't create mod entry if Turnitin disabled.

I placed the check here because we still need the ability to update _mod table if an instructor is disabling Turnitin for an existing assignment.