### PR TITLE
INT-15223: Move /api from input to constant

### DIFF
--- a/classes/request.class.php
+++ b/classes/request.class.php
@@ -241,19 +241,27 @@ class plagiarism_turnitinsim_request {
     public function test_connection($apiurl, $apikey) {
 
         $validurlregex = '/.+\.(turnitin\.com|turnitinuk\.com|turnitin\.dev|turnitin\.org|tii-sandbox\.com)$/m';
+        $validurlregexwithapi = '/.+\.(turnitin\.com|turnitinuk\.com|turnitin\.dev|turnitin\.org|tii-sandbox\.com)\/api$/m';
 
         if (empty($apikey) || empty($apiurl)) {
             $data["connection_status"] = TURNITINSIM_HTTP_BAD_REQUEST;
             return json_encode($data);
         }
 
-        if (!preg_match($validurlregex, $apiurl)) {
+        if (!preg_match($validurlregex, $apiurl) && !preg_match($validurlregexwithapi, $apiurl)) {
             $data["connection_status"] = TURNITINSIM_HTTP_BAD_REQUEST;
 
             if ($this->logger) {
                 $this->logger->info('Invalid Turnitin URL: ', array($apiurl));
             }
             return json_encode($data);
+        }
+
+        if (preg_match($validurlregexwithapi, $apiurl)) {
+            if ($this->logger) {
+                $this->logger->info('Stripping /api from Turnitin URL for connection test: ', array($apiurl));
+            }
+            $apiurl = str_replace("/api", '', $apiurl);
         }
 
         $this->set_apiurl($apiurl);

--- a/classes/request.class.php
+++ b/classes/request.class.php
@@ -243,15 +243,14 @@ class plagiarism_turnitinsim_request {
         //Strip any trailing / chars from api url.
         $apiurl = rtrim($apiurl, '/');
 
-        $validurlregex = '/.+\.(turnitin\.com|turnitinuk\.com|turnitin\.dev|turnitin\.org|tii-sandbox\.com)$/m';
-        $validurlregexwithapi = '/.+\.(turnitin\.com|turnitinuk\.com|turnitin\.dev|turnitin\.org|tii-sandbox\.com)\/api$/m';
+        $validurlregex = '/.+\.(turnitin\.com|turnitinuk\.com|turnitin\.dev|turnitin\.org|tii-sandbox\.com)(\/api)?$/m';
 
         if (empty($apikey) || empty($apiurl)) {
             $data["connection_status"] = TURNITINSIM_HTTP_BAD_REQUEST;
             return json_encode($data);
         }
 
-        if (!preg_match($validurlregex, $apiurl) && !preg_match($validurlregexwithapi, $apiurl)) {
+        if (!preg_match($validurlregex, $apiurl)) {
             $data["connection_status"] = TURNITINSIM_HTTP_BAD_REQUEST;
 
             if ($this->logger) {
@@ -260,12 +259,7 @@ class plagiarism_turnitinsim_request {
             return json_encode($data);
         }
 
-        if (preg_match($validurlregexwithapi, $apiurl)) {
-            if ($this->logger) {
-                $this->logger->info('Stripping /api from Turnitin URL for connection test: ', array($apiurl));
-            }
-            $apiurl = str_replace("/api", '', $apiurl);
-        }
+        $apiurl = str_replace("/api", '', $apiurl);
 
         $this->set_apiurl($apiurl);
         $this->set_apikey($apikey);

--- a/classes/request.class.php
+++ b/classes/request.class.php
@@ -240,6 +240,9 @@ class plagiarism_turnitinsim_request {
      */
     public function test_connection($apiurl, $apikey) {
 
+        //Strip any trailing / chars from api url.
+        $apiurl = rtrim($apiurl, '/');
+
         $validurlregex = '/.+\.(turnitin\.com|turnitinuk\.com|turnitin\.dev|turnitin\.org|tii-sandbox\.com)$/m';
         $validurlregexwithapi = '/.+\.(turnitin\.com|turnitinuk\.com|turnitin\.dev|turnitin\.org|tii-sandbox\.com)\/api$/m';
 

--- a/classes/request.class.php
+++ b/classes/request.class.php
@@ -123,10 +123,6 @@ class plagiarism_turnitinsim_request {
 
         $tiiurl = $this->get_apiurl();
 
-        if ($requesttype === 'logging') {
-            $tiiurl = str_replace('/api', '', $this->get_apiurl());
-        }
-
         if ($this->logger) {
             $this->logger->info('[' . $method . '] Request to: ' . $tiiurl . $endpoint);
             $this->logger->info('Headers: ', $this->headers);
@@ -244,7 +240,7 @@ class plagiarism_turnitinsim_request {
      */
     public function test_connection($apiurl, $apikey) {
 
-        $validurlregex = '/.+\.(turnitin\.com|turnitinuk\.com|turnitin\.dev|turnitin\.org|tii-sandbox\.com)\/api$/m';
+        $validurlregex = '/.+\.(turnitin\.com|turnitinuk\.com|turnitin\.dev|turnitin\.org|tii-sandbox\.com)$/m';
 
         if (empty($apikey) || empty($apiurl)) {
             $data["connection_status"] = TURNITINSIM_HTTP_BAD_REQUEST;

--- a/classes/setup_form.class.php
+++ b/classes/setup_form.class.php
@@ -171,15 +171,17 @@ class plagiarism_turnitinsim_setup_form extends moodleform {
             }
         }
 
-        $validurlregex = '/.+\.(turnitin\.com|turnitinuk\.com|turnitin\.dev|turnitin\.org|tii-sandbox\.com)\/api$/m';
+        $validurlregexwithapi = '/.+\.(turnitin\.com|turnitinuk\.com|turnitin\.dev|turnitin\.org|tii-sandbox\.com)\/api$/m';
 
         if ((!empty($data->turnitinapiurl))) {
-            if (preg_match($validurlregex, $data->turnitinapiurl)) {
+            //Strip any trailing / chars from api url.
+            $apiurl = rtrim($data->turnitinapiurl, '/');
+            if (preg_match($validurlregexwithapi, $apiurl)) {
                 $logger = new plagiarism_turnitinsim_logger();
-                $logger->info('Stripping /api from Turnitin URL on save: ', array($data->turnitinapiurl));
-                $turnitinapiurl = str_replace("/api", '', $data->turnitinapiurl);
+                $logger->info('Stripping /api from Turnitin URL on save: ', array($apiurl));
+                $turnitinapiurl = str_replace("/api", '', $apiurl);
             } else {
-                $turnitinapiurl = $data->turnitinapiurl;
+                $turnitinapiurl = $apiurl;
             }
         } else {
             $turnitinapiurl = '';

--- a/classes/setup_form.class.php
+++ b/classes/setup_form.class.php
@@ -171,7 +171,20 @@ class plagiarism_turnitinsim_setup_form extends moodleform {
             }
         }
 
-        $turnitinapiurl = (!empty($data->turnitinapiurl)) ? $data->turnitinapiurl : '';
+        $validurlregex = '/.+\.(turnitin\.com|turnitinuk\.com|turnitin\.dev|turnitin\.org|tii-sandbox\.com)\/api$/m';
+
+        if ((!empty($data->turnitinapiurl))) {
+            if (preg_match($validurlregex, $data->turnitinapiurl)) {
+                $logger = new plagiarism_turnitinsim_logger();
+                $logger->info('Stripping /api from Turnitin URL on save: ', array($data->turnitinapiurl));
+                $turnitinapiurl = str_replace("/api", '', $data->turnitinapiurl);
+            } else {
+                $turnitinapiurl = $data->turnitinapiurl;
+            }
+        } else {
+            $turnitinapiurl = '';
+        }
+
         $turnitinapikey = (!empty($data->turnitinapikey)) ? $data->turnitinapikey : '';
         $turnitinenablelogging = (!empty($data->turnitinenablelogging)) ? $data->turnitinenablelogging : 0;
         $turnitinenableremotelogging = (!empty($data->turnitinenableremotelogging)) ? $data->turnitinenableremotelogging : 0;

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -304,5 +304,16 @@ function xmldb_plagiarism_turnitinsim_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2020092301, 'plagiarism', 'turnitinsim');
     }
 
+    /**
+     * Remove "/api" from the turnitin URL as its been added to the endpoint constants.
+     */
+    if ($oldversion > 2021011801) {
+        $turnitinapiurl = get_config('plagiarism_turnitinsim', 'turnitinapiurl');
+
+        set_config('turnitinapiurl', str_replace("/api", '', $turnitinapiurl), 'plagiarism_turnitinsim');
+
+        upgrade_plugin_savepoint(true, 2021011804, 'plagiarism', 'turnitinsim');
+    }
+
     return true;
 }

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -312,7 +312,7 @@ function xmldb_plagiarism_turnitinsim_upgrade($oldversion) {
 
         set_config('turnitinapiurl', str_replace("/api", '', $turnitinapiurl), 'plagiarism_turnitinsim');
 
-        upgrade_plugin_savepoint(true, 2021011804, 'plagiarism', 'turnitinsim');
+        upgrade_plugin_savepoint(true, 2021011801, 'plagiarism', 'turnitinsim');
     }
 
     return true;

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -307,12 +307,12 @@ function xmldb_plagiarism_turnitinsim_upgrade($oldversion) {
     /**
      * Remove "/api" from the turnitin URL as its been added to the endpoint constants.
      */
-    if ($oldversion > 2021011801) {
+    if ($oldversion > 2021020401) {
         $turnitinapiurl = get_config('plagiarism_turnitinsim', 'turnitinapiurl');
 
         set_config('turnitinapiurl', str_replace("/api", '', $turnitinapiurl), 'plagiarism_turnitinsim');
 
-        upgrade_plugin_savepoint(true, 2021011801, 'plagiarism', 'turnitinsim');
+        upgrade_plugin_savepoint(true, 2021020401, 'plagiarism', 'turnitinsim');
     }
 
     return true;

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -28,7 +28,7 @@ defined('MOODLE_INTERNAL') || die();
 /**
  * Database upgrade script for plagiarism_turnitinsim component.
  *
- * @param int $oldversion The version that is currently installed.
+ * @param int $oldversion The version that is currently installed. (The version being upgraded from)
  * @return bool true if upgrade was successful.
  * @throws ddl_exception
  * @throws ddl_table_missing_exception
@@ -307,7 +307,9 @@ function xmldb_plagiarism_turnitinsim_upgrade($oldversion) {
     /**
      * Remove "/api" from the turnitin URL as its been added to the endpoint constants.
      */
-    if ($oldversion > 2021020401) {
+    if ($oldversion < 2021020401) {
+        (new handle_deprecation)->unset_turnitinsim_use();
+
         $turnitinapiurl = get_config('plagiarism_turnitinsim', 'turnitinapiurl');
 
         set_config('turnitinapiurl', str_replace("/api", '', $turnitinapiurl), 'plagiarism_turnitinsim');

--- a/utilities/constants.php
+++ b/utilities/constants.php
@@ -57,15 +57,15 @@ define('TURNITINSIM_HTTP_UNPROCESSABLE_ENTITY', 422);
 define('TURNITINSIM_HTTP_UNAVAILABLE_FOR_LEGAL_REASONS', 451);
 
 // API Endpoints.
-define('TURNITINSIM_ENDPOINT_CREATE_SUBMISSION', '/v1/submissions');
-define('TURNITINSIM_ENDPOINT_GET_SUBMISSION_INFO', '/v1/submissions/{{submission_id}}');
-define('TURNITINSIM_ENDPOINT_UPLOAD_SUBMISSION', '/v1/submissions/{{submission_id}}/original');
-define('TURNITINSIM_ENDPOINT_SIMILARITY_REPORT', '/v1/submissions/{{submission_id}}/similarity');
-define('TURNITINSIM_ENDPOINT_CV_LAUNCH', '/v1/submissions/{{submission_id}}/viewer-url');
-define('TURNITINSIM_ENDPOINT_WEBHOOKS', '/v1/webhooks');
-define('TURNITINSIM_ENDPOINT_GET_WEBHOOK', '/v1/webhooks/{{webhook_id}}');
-define('TURNITINSIM_ENDPOINT_GET_LATEST_EULA', '/v1/eula/latest');
-define('TURNITINSIM_ENDPOINT_GET_FEATURES_ENABLED', '/v1/features-enabled');
+define('TURNITINSIM_ENDPOINT_CREATE_SUBMISSION', '/api/v1/submissions');
+define('TURNITINSIM_ENDPOINT_GET_SUBMISSION_INFO', '/api/v1/submissions/{{submission_id}}');
+define('TURNITINSIM_ENDPOINT_UPLOAD_SUBMISSION', '/api/v1/submissions/{{submission_id}}/original');
+define('TURNITINSIM_ENDPOINT_SIMILARITY_REPORT', '/api/v1/submissions/{{submission_id}}/similarity');
+define('TURNITINSIM_ENDPOINT_CV_LAUNCH', '/api/v1/submissions/{{submission_id}}/viewer-url');
+define('TURNITINSIM_ENDPOINT_WEBHOOKS', '/api/v1/webhooks');
+define('TURNITINSIM_ENDPOINT_GET_WEBHOOK', '/api/v1/webhooks/{{webhook_id}}');
+define('TURNITINSIM_ENDPOINT_GET_LATEST_EULA', '/api/v1/eula/latest');
+define('TURNITINSIM_ENDPOINT_GET_FEATURES_ENABLED', '/api/v1/features-enabled');
 define('TURNITINSIM_ENDPOINT_LOGGING', '/remote-logging/api/log');
 
 // URLs.

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2021011801;
+$plugin->version = 2021020401;
 $plugin->release = "v1.2";
 $plugin->requires = 2017051500;
 $plugin->component = 'plagiarism_turnitinsim';


### PR DESCRIPTION
I've prefixed the TII URL's with /api so that the user no longer needs to input it when setting up the plugin
Once the user upgrades their API URL should change to remove /api

**Update**
When the user tests connection /api and no path are acceptable URLS. If the user uses /api then it will be stripped out for the purpose of the connection test.
When the user submits if the URL has /api then it is stripped out when saved to the DB. When the user reloads the page the URL text box will contain the URL without /api as that value is loaded from the DB. 