### PR TITLE
INT-15227: Modify default value of quizanswer field

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -304,5 +304,16 @@ function xmldb_plagiarism_turnitinsim_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2020092301, 'plagiarism', 'turnitinsim');
     }
 
+    if ($oldversion < 2021020402) {
+        (new handle_deprecation)->unset_turnitinsim_use();
+
+        $table = new xmldb_table('plagiarism_turnitinsim_sub');
+        $field = new xmldb_field('quizanswer', XMLDB_TYPE_CHAR, '32', null, false, null, 0, 'tiiretrytime');
+
+        $dbman->change_field_default($table, $field);
+
+        upgrade_plugin_savepoint(true, 2021020402, 'plagiarism', 'turnitinsim');
+    }
+
     return true;
 }

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2021011801;
+$plugin->version = 2021020402;
 $plugin->release = "v1.2";
 $plugin->requires = 2017051500;
 $plugin->component = 'plagiarism_turnitinsim';


### PR DESCRIPTION
I've used the version 2021020402 as compared to 2021020401 for the /api upgrade change. When the release goes out I assume the change numbers for the two upgrade.php PR's would need to be different