### PR TITLE
INT-15265 - Fixes for null/empty userids

### DIFF
--- a/classes/request.class.php
+++ b/classes/request.class.php
@@ -240,7 +240,7 @@ class plagiarism_turnitinsim_request {
      */
     public function test_connection($apiurl, $apikey) {
 
-        //Strip any trailing / chars from api url.
+        // Strip any trailing / chars from api url.
         $apiurl = rtrim($apiurl, '/');
 
         $validurlregex = '/.+\.(turnitin\.com|turnitinuk\.com|turnitin\.dev|turnitin\.org|tii-sandbox\.com)(\/api)?$/m';

--- a/classes/setup_form.class.php
+++ b/classes/setup_form.class.php
@@ -174,7 +174,7 @@ class plagiarism_turnitinsim_setup_form extends moodleform {
         $validurlregexwithapi = '/.+\.(turnitin\.com|turnitinuk\.com|turnitin\.dev|turnitin\.org|tii-sandbox\.com)\/api$/m';
 
         if ((!empty($data->turnitinapiurl))) {
-            //Strip any trailing / chars from api url.
+            // Strip any trailing / chars from api url.
             $apiurl = rtrim($data->turnitinapiurl, '/');
             if (preg_match($validurlregexwithapi, $apiurl)) {
                 $logger = new plagiarism_turnitinsim_logger();

--- a/classes/user.class.php
+++ b/classes/user.class.php
@@ -70,6 +70,10 @@ class plagiarism_turnitinsim_user {
     public function __construct($userid) {
         global $DB;
 
+        if (empty($userid)) {
+            return;
+        }
+
         $this->set_userid($userid);
 
         // If there is no user record then create one.

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -305,27 +305,22 @@ function xmldb_plagiarism_turnitinsim_upgrade($oldversion) {
     }
 
     /**
-     * Remove "/api" from the turnitin URL as its been added to the endpoint constants.
+     * Remove "/api" from the Turnitin URL as its been added to the endpoint constants.
+     * Update field defaults for quizanswer to match install.xml.
      */
-    if ($oldversion < 2021020401) {
+    if ($oldversion < 2021022201) {
         (new handle_deprecation)->unset_turnitinsim_use();
 
         $turnitinapiurl = get_config('plagiarism_turnitinsim', 'turnitinapiurl');
 
         set_config('turnitinapiurl', str_replace("/api", '', $turnitinapiurl), 'plagiarism_turnitinsim');
 
-        upgrade_plugin_savepoint(true, 2021020401, 'plagiarism', 'turnitinsim');
-    }
-
-    if ($oldversion < 2021020402) {
-        (new handle_deprecation)->unset_turnitinsim_use();
-
         $table = new xmldb_table('plagiarism_turnitinsim_sub');
         $field = new xmldb_field('quizanswer', XMLDB_TYPE_CHAR, '32', null, false, null, 0, 'tiiretrytime');
 
         $dbman->change_field_default($table, $field);
 
-        upgrade_plugin_savepoint(true, 2021020402, 'plagiarism', 'turnitinsim');
+        upgrade_plugin_savepoint(true, 2021022201, 'plagiarism', 'turnitinsim');
     }
 
     return true;

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -304,10 +304,8 @@ function xmldb_plagiarism_turnitinsim_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2020092301, 'plagiarism', 'turnitinsim');
     }
 
-    /**
-     * Remove "/api" from the Turnitin URL as its been added to the endpoint constants.
-     * Update field defaults for quizanswer to match install.xml.
-     */
+    // Remove "/api" from the Turnitin URL as its been added to the endpoint constants.
+    // Update field defaults for quizanswer to match install.xml.
     if ($oldversion < 2021022201) {
         (new handle_deprecation)->unset_turnitinsim_use();
 

--- a/lib.php
+++ b/lib.php
@@ -342,7 +342,7 @@ class plagiarism_plugin_turnitinsim extends plagiarism_plugin {
                         break;
                 }
 
-            } elseif($linkarray['userid'] != null) {
+            } else if ($linkarray['userid'] != null) {
                 if ($instructor && $linkarray['userid'] === "0") {
                     return $output;
                 } else {

--- a/lib.php
+++ b/lib.php
@@ -179,7 +179,7 @@ class plagiarism_plugin_turnitinsim extends plagiarism_plugin {
             $filearea = $file->get_filearea();
 
             $nonsubmittingareas = array("feedback_files", "introattachment");
-            $allowedcomponents = array("assignsubmission_file", "mod_forum", "mod_workshop", "question");
+            $allowedcomponents = array("assignsubmission_file", "mod_assign", "mod_forum", "mod_workshop", "question");
 
             if ((in_array($filearea, $nonsubmittingareas)) || !in_array($file->get_component(), $allowedcomponents)) {
                 return $output;

--- a/lib.php
+++ b/lib.php
@@ -161,7 +161,7 @@ class plagiarism_plugin_turnitinsim extends plagiarism_plugin {
      * @throws moodle_exception
      */
     public function get_links($linkarray) {
-        global $DB, $OUTPUT, $PAGE;
+        global $DB, $OUTPUT, $PAGE, $USER;
 
         // Require the relevant JS modules.  Only include once.
         static $jsloaded;
@@ -177,8 +177,11 @@ class plagiarism_plugin_turnitinsim extends plagiarism_plugin {
         if (!empty($linkarray["file"])) {
             $file = $linkarray["file"];
             $filearea = $file->get_filearea();
+
             $nonsubmittingareas = array("feedback_files", "introattachment");
-            if (in_array($filearea, $nonsubmittingareas)) {
+            $allowedcomponents = array("assignsubmission_file", "mod_forum", "mod_workshop", "question");
+
+            if ((in_array($filearea, $nonsubmittingareas)) || !in_array($file->get_component(), $allowedcomponents)) {
                 return $output;
             }
         }
@@ -235,6 +238,7 @@ class plagiarism_plugin_turnitinsim extends plagiarism_plugin {
         if ((!empty($linkarray['file'])) || (!empty($linkarray['content']))) {
             $submissionid = '';
             $eulaconfirm = '';
+            $status = '';
             $showresubmitlink = false;
             $submission = null;
 
@@ -338,7 +342,13 @@ class plagiarism_plugin_turnitinsim extends plagiarism_plugin {
                         break;
                 }
 
-            } else {
+            } elseif($linkarray['userid'] != null) {
+                if ($instructor && $linkarray['userid'] === "0") {
+                    return $output;
+                } else {
+                    $linkarray['userid'] = $USER->id;
+                }
+
                 // If the plugin was enabled after a submission was made then it will not have been sent to Turnitin. Queue it.
                 $moduleclass = 'plagiarism_turnitinsim_'.$cm->modname;
                 $moduleobject = new $moduleclass;
@@ -351,7 +361,7 @@ class plagiarism_plugin_turnitinsim extends plagiarism_plugin {
 
                 if ($plagiarismfile->status === TURNITINSIM_SUBMISSION_STATUS_EULA_NOT_ACCEPTED) {
                     $eula = new plagiarism_turnitinsim_eula();
-                    $statusset = $eula->get_eula_status($cm->id, $submission->gettype());
+                    $statusset = $eula->get_eula_status($cm->id, $plagiarismfile->type);
                     $status = $statusset['eula-status'];
                     $eulaconfirm = $statusset['eula-confirm'];
                 } else {

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2021020402;
+$plugin->version = 2021022201;
 $plugin->release = "v1.2";
 $plugin->requires = 2017051500;
 $plugin->component = 'plagiarism_turnitinsim';


### PR DESCRIPTION
This pull request fixes three issues:

1) An issue mentioned in https://github.com/turnitin/moodle-plagiarism_turnitinsim/issues/89 where using the annotate PDF module would cause the plugin to attempt to save a submission for the annotated PDF. This resulted in a null userid error.

2) If Turnitin was enabled after submissions have already been made and a student who had not already accepted the EULA views the inbox before the instructor then the student would see an error. On the first time only - if they refresh the page they didn't see an error. This is because on the first view we'd create the submission but fail because we're checking in the wrong place for their EULA acceptance, but on the following views a different block of code is hit since the submission then exists.

3) An issue where text submissions for group submissions would not save correctly if the plugin was enabled after the submissions were made. Bit of an edge case, but it is as a result of the Moodle bug https://tracker.moodle.org/browse/MDL-63932 As a workaround, the submissions in this scenario can only be saved if the student views the inbox.

I've added another check to ensure that we can never attempt to insert a user to the users table if the userid is empty. Just in case there is some other edge case out there that might get us into that situation.

I've also merged the two database upgrade blocks added in other pull requests.