### PR TITLE
Fix for instructor EULA acceptance in forum posts.

### DIFF
--- a/classes/eula.class.php
+++ b/classes/eula.class.php
@@ -123,7 +123,7 @@ class plagiarism_turnitinsim_eula {
      *
      * @param int $cmid - course module id
      * @param string $submissiontype - The type of submission - file or content.
-     * @param string $submissionuserid - The userid the submission is against.type of submission - file or content.
+     * @param string $submissionuserid - The userid the submission is against.
      * @return array The HTML elements for a EULA NOT ACCEPTED status.
      * @throws coding_exception
      * @throws dml_exception

--- a/classes/eula.class.php
+++ b/classes/eula.class.php
@@ -123,15 +123,16 @@ class plagiarism_turnitinsim_eula {
      *
      * @param int $cmid - course module id
      * @param string $submissiontype - The type of submission - file or content.
+     * @param string $submissionuserid - The userid the submission is against.type of submission - file or content.
      * @return array The HTML elements for a EULA NOT ACCEPTED status.
      * @throws coding_exception
      * @throws dml_exception
      */
-    public function get_eula_status($cmid, $submissiontype) {
-        global $OUTPUT;
+    public function get_eula_status($cmid, $submissiontype, $submissionuserid) {
+        global $OUTPUT, $USER;
 
         $eulaconfirm = '';
-        if (!has_capability('plagiarism/turnitinsim:viewfullreport', context_module::instance($cmid))) {
+        if ($USER->id == $submissionuserid) {
             $plagiarismpluginturnitinsim = new plagiarism_plugin_turnitinsim();
             $eulaconfirm = $plagiarismpluginturnitinsim->print_disclosure($cmid, $submissiontype);
         }

--- a/lib.php
+++ b/lib.php
@@ -299,7 +299,7 @@ class plagiarism_plugin_turnitinsim extends plagiarism_plugin {
 
                     case TURNITINSIM_SUBMISSION_STATUS_EULA_NOT_ACCEPTED:
                         $eula = new plagiarism_turnitinsim_eula();
-                        $statusset = $eula->get_eula_status($cm->id, $submission->gettype());
+                        $statusset = $eula->get_eula_status($cm->id, $submission->gettype(), $submission->getuserid());
                         $status = $statusset['eula-status'];
                         $eulaconfirm = $statusset['eula-confirm'];
                         $showresubmitlink = false;
@@ -365,7 +365,7 @@ class plagiarism_plugin_turnitinsim extends plagiarism_plugin {
 
                 if ($plagiarismfile->status === TURNITINSIM_SUBMISSION_STATUS_EULA_NOT_ACCEPTED) {
                     $eula = new plagiarism_turnitinsim_eula();
-                    $statusset = $eula->get_eula_status($cm->id, $plagiarismfile->type);
+                    $statusset = $eula->get_eula_status($cm->id, $plagiarismfile->type, $plagiarismfile->userid);
                     $status = $statusset['eula-status'];
                     $eulaconfirm = $statusset['eula-confirm'];
                 } else {

--- a/tests/classes/eula.class_test.php
+++ b/tests/classes/eula.class_test.php
@@ -226,7 +226,7 @@ class eula_class_testcase extends advanced_testcase {
         $cm = get_coursemodule_from_instance('assign', $module->id);
 
         $tseula = new plagiarism_turnitinsim_eula();
-        $result = $tseula->get_eula_status($cm->id, 'file');
+        $result = $tseula->get_eula_status($cm->id, 'file', $this->student->id);
 
         handle_deprecation::assertcontains($this,
             get_string('eulalink', 'plagiarism_turnitinsim', '?lang=en-US'), $result['eula-confirm']);
@@ -288,9 +288,10 @@ class eula_class_testcase extends advanced_testcase {
         $cm = get_coursemodule_from_instance('assign', $module->id);
 
         $tseula = new plagiarism_turnitinsim_eula();
-        $result = $tseula->get_eula_status($cm->id, 'file');
+        $result = $tseula->get_eula_status($cm->id, 'file', $this->instructor->id);
 
-        $this->assertEmpty($result['eula-confirm']);
+        handle_deprecation::assertcontains($this,
+            get_string('eulalink', 'plagiarism_turnitinsim', '?lang=en-US'), $result['eula-confirm']);
         handle_deprecation::assertcontains($this,
             get_string('submissiondisplayerror:eulanotaccepted_help', 'plagiarism_turnitinsim'), $result['eula-status']);
     }


### PR DESCRIPTION
Change EULA acceptance check so that instructors can accept their EULA in forum posts after declining the EULA.

Changed the EULA logic to simply check for the current user, rather than just students.