### PR TITLE
Fix for draft submissions where process draft is turned on

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -648,8 +648,8 @@ class plagiarism_plugin_turnitinsim extends plagiarism_plugin {
 
             $submissions = $DB->get_records_select(
                 'plagiarism_turnitinsim_sub',
-                'cm = ? AND userid = ? AND itemid = ? AND status != ?',
-                array($cm->id, $author, $itemid, TURNITINSIM_SUBMISSION_STATUS_EULA_NOT_ACCEPTED)
+                'cm = ? AND userid = ? AND itemid = ? AND status != ? AND status != ?',
+                array($cm->id, $author, $itemid, TURNITINSIM_SUBMISSION_STATUS_EULA_NOT_ACCEPTED, TURNITINSIM_SUBMISSION_STATUS_COMPLETE)
             );
 
             foreach ($submissions as $submission) {

--- a/lib.php
+++ b/lib.php
@@ -648,7 +648,7 @@ class plagiarism_plugin_turnitinsim extends plagiarism_plugin {
 
             $submissions = $DB->get_records_select(
                 'plagiarism_turnitinsim_sub',
-                'cm = ? AND userid = ? AND itemid = ? AND status != ? AND status != ?',
+                'cm = ? AND userid = ? AND itemid = ? AND status NOT IN (?, ?)',
                 array($cm->id, $author, $itemid, TURNITINSIM_SUBMISSION_STATUS_EULA_NOT_ACCEPTED, TURNITINSIM_SUBMISSION_STATUS_COMPLETE)
             );
 


### PR DESCRIPTION
This fixes the issue where if process draft submissions is turned on, a submission would move from completed with a score to pending and stay in pending - when the student submits their draft.