### PR TITLE
Revert mod_quiz to quiz

### DIFF
--- a/classes/submission.class.php
+++ b/classes/submission.class.php
@@ -553,7 +553,7 @@ class plagiarism_turnitinsim_submission {
                 }
 
                 // Queue each answer to a question.
-                $attempt = 'mod_quiz\quiz_attempt'::create($this->getitemid());
+                $attempt = quiz_attempt::create($this->getitemid());
                 foreach ($attempt->get_slots() as $slot) {
                     $qa = $attempt->get_question_attempt($slot);
                     if ($this->getidentifier() == sha1($qa->get_response_summary())) {

--- a/lib.php
+++ b/lib.php
@@ -862,7 +862,7 @@ class plagiarism_plugin_turnitinsim extends plagiarism_plugin {
         $submitter = new plagiarism_turnitinsim_user($eventdata['userid']);
 
         // Queue every question submitted in a quiz attempt.
-        $attempt = 'mod_quiz\quiz_attempt'::create($eventdata['objectid']);
+        $attempt = quiz_attempt::create($eventdata['objectid']);
         $context = context_module::instance($attempt->get_cmid());
         foreach ($attempt->get_slots() as $slot) {
             $eventdata['other']['pathnamehashes'] = array();


### PR DESCRIPTION
Reverting `mod_quiz\` declaration for quizzes as `mod_quiz\ `will be required for future versions of Moodle, but is not supported for 4.1. Keeping as is to support both Moodle 4.1-4.3. Will need to revisit as we move support away from 4.1 in the future.