### PR TITLE
Add explicit cast to int for DateTime

### DIFF
--- a/vendor/katzgrau/klogger/src/Logger.php
+++ b/vendor/katzgrau/klogger/src/Logger.php
@@ -305,7 +305,7 @@ class Logger extends AbstractLogger
     {
         $originalTime = microtime(true);
         $micro = sprintf("%06d", ($originalTime - floor($originalTime)) * 1000000);
-        $date = new DateTime(date('Y-m-d H:i:s.'.$micro, $originalTime));
+        $date = new DateTime(date('Y-m-d H:i:s.'.$micro, (int)$originalTime));
 
         return $date->format($this->options['dateFormat']);
     }


### PR DESCRIPTION
To resolve deprecation warnings we should add an explicit cast to int when constructing a DateTime