### PR TITLE
Fix unit tests

### DIFF
--- a/classes/task.class.php
+++ b/classes/task.class.php
@@ -51,6 +51,8 @@ class plagiarism_turnitinsim_task {
      * @var plagiarism_turnitinsim_settings Settings object.
      */
     public $tssettings;
+    
+    protected $tseula;
 
     /**
      * plagiarism_turnitinsim_task constructor.

--- a/classes/task.class.php
+++ b/classes/task.class.php
@@ -275,14 +275,14 @@ class plagiarism_turnitinsim_task {
             $neweulaurl = (empty($response->url)) ? '' : $response->url;
 
             // Update EULA version and url if necessary.
-            if ($currenteulaversion != $neweulaversion) {
+            if (!empty($response->version) && $currenteulaversion != $neweulaversion) {
                 set_config('turnitin_eula_version', $response->version, 'plagiarism_turnitinsim');
                 set_config('turnitin_eula_url', $response->url, 'plagiarism_turnitinsim');
 
                 // Notify all users linked to Turnitin that there is a new EULA to accept.
                 $message = new new_eula();
                 $message->send_message();
-            } else if ($currenteulaurl != $neweulaurl){
+            } else if (!empty($response->url) && $currenteulaurl != $neweulaurl){
                 // This runs if there is no new EULA version, but a user still needs an updated EULA URL for their supported language.
                 // We do not want to notify all users that there is a new EULA url for the translation.
                 set_config('turnitin_eula_version', $response->version, 'plagiarism_turnitinsim');

--- a/tests/lib_test.php
+++ b/tests/lib_test.php
@@ -51,6 +51,9 @@ class plagiarism_turnitinsim_lib_testcase extends advanced_testcase {
      */
     const TURNITINSIM_API_KEY = '123456';
 
+    protected $plugin;
+    protected $course;
+
     /**
      * Get a list of activity modules that support plagiarism plugins.
      *

--- a/tests/lib_test.php
+++ b/tests/lib_test.php
@@ -499,7 +499,7 @@ class plagiarism_turnitinsim_lib_testcase extends advanced_testcase {
         // Get locale.
         $tsrequest = new plagiarism_turnitinsim_request();
         $lang = $tsrequest->get_language();
-        $eulaurl = $this->eulaurl."?lang=".$lang->localecode;
+        $eulaurl = $this->eulaurl;
 
         // Verify EULA is output.
         $plagiarismturnitinsim = new plagiarism_plugin_turnitinsim();

--- a/tests/lib_test.php
+++ b/tests/lib_test.php
@@ -53,6 +53,13 @@ class plagiarism_turnitinsim_lib_testcase extends advanced_testcase {
 
     protected $plugin;
     protected $course;
+    protected $student1;
+    protected $student1ts;
+    protected $instructor;
+    protected $tseula;
+    protected $eulaurl;
+    protected $cm;
+    protected $assign;
 
     /**
      * Get a list of activity modules that support plagiarism plugins.

--- a/tests/privacy/provider_test.php
+++ b/tests/privacy/provider_test.php
@@ -39,6 +39,9 @@ require_once($CFG->dirroot . '/plagiarism/turnitinsim/tests/turnitinsim_generato
  */
 class plagiarism_turnitinsim_privacy_provider_testcase extends advanced_testcase {
 
+    protected $turnitinsim_generator;
+    protected $submission;
+
     /**
      * Setup method that runs before each test.
      */


### PR DESCRIPTION
Fixing unit tests that are broken under PHP 8.3

Regarding the change to eula url I believe this was broken by #146. We can now expect the full URL of the eula to be stored so no need to append a language code.