### PR TITLE
Remove deprecated callbacks

### DIFF
--- a/classes/defaults_form.class.php
+++ b/classes/defaults_form.class.php
@@ -43,7 +43,7 @@ class plagiarism_turnitinsim_defaults_form extends moodleform {
         $mform =& $this->_form;
 
         $plugin = new plagiarism_plugin_turnitinsim();
-        $plugin->get_form_elements_module($mform, context_system::instance());
+        $plugin->plagiarism_turnitinsim_coursemodule_standard_elements($mform, context_system::instance());
 
         $this->add_action_buttons(true);
     }


### PR DESCRIPTION
We are using deprecated callbacks to show the settings forms: https://tracker.moodle.org/browse/MDL-67526

We are already using the newer callbacks, we just need to remove references to deprecated ones as we no longer need these for compatibility reasons