### PR TITLE
Move settings logic into class method

### DIFF
--- a/classes/defaults_form.class.php
+++ b/classes/defaults_form.class.php
@@ -43,7 +43,7 @@ class plagiarism_turnitinsim_defaults_form extends moodleform {
         $mform =& $this->_form;
 
         $plugin = new plagiarism_plugin_turnitinsim();
-        $plugin->plagiarism_turnitinsim_coursemodule_standard_elements($mform, context_system::instance());
+        $plugin->add_elements_to_settings_form($mform, context_system::instance());
 
         $this->add_action_buttons(true);
     }

--- a/lib.php
+++ b/lib.php
@@ -45,6 +45,97 @@ require_once( __DIR__ . '/classes/task.class.php' );
 class plagiarism_plugin_turnitinsim extends plagiarism_plugin {
 
     /**
+     * Add settings form elements to either defaults form or assignment settings form
+     *
+     * @param object $mform - Moodle form
+     * @param object $context - current context
+     * @param string $modulename - Name of the module
+     * @return void
+     * @throws coding_exception
+     * @throws dml_exception
+     */
+    public function add_elements_to_settings_form($mform, $context, $modulename = "") {
+        $canconfigureplugin = false;
+
+        static $hassettings;
+        if ($hassettings) {
+            return;
+        }
+
+        $cmid = optional_param('update', 0, PARAM_INT);
+
+        $location = ($context == context_system::instance()) ? 'defaults' : 'module';
+
+        // Get whether plugin is enabled for this module.
+        $moduletiienabled = empty($modulename) ? "0" : get_config('plagiarism_turnitinsim',
+            'turnitinmodenabled'.substr($modulename, 4));
+
+        if ($location === 'module') {
+            // Exit if Turnitin is not being used for this activity type and location is not default.
+            if (empty($moduletiienabled)) {
+                return;
+            }
+
+            // Course ID is only passed in on new module - if updating then get it from module id.
+            $courseid = optional_param('course', 0, PARAM_INT);
+            $id = optional_param('id', 0, PARAM_INT);
+
+            if (empty($courseid)) {
+                $checkcourse = (!empty($cmid)) ? $cmid : $id;
+                $course = get_coursemodule_from_id('', $checkcourse);
+
+                // If it is still empty, return to avoid an error.
+                if (empty($course)) {
+                    return;
+                }
+
+                $courseid = $course->course;
+            }
+
+            // Exit if this user does not have permissions to configure the plugin.
+            if (has_capability('plagiarism/turnitinsim:enable', context_course::instance($courseid))) {
+                $canconfigureplugin = true;
+            }
+        } else {
+            $canconfigureplugin = true;
+        }
+
+        $form = new plagiarism_turnitinsim_settings();
+        $form->add_settings_to_module($mform, $canconfigureplugin, $location, $modulename);
+
+        if ($modsettings = $this->get_settings( $cmid )) {
+
+            // Set the default value for each option as the value we have stored.
+            foreach ($modsettings as $element => $value) {
+
+                // If the element name starts with exclude it needs to be placed in the exclude options group.
+                if ( substr($element, 0, 7) == 'exclude' ) {
+                    $mform->setDefault('excludeoptions['.$element.']', $value);
+                }
+
+                // If the element name starts with reportgen it needs to be placed in the report gen options group.
+                if ( substr($element, 0, 9) == 'reportgen' ) {
+                    $mform->setDefault('reportgenoptions['.$element.']', $value);
+                }
+
+                // If the element is addtoindex it needs to be placed in the index options group.
+                if ($element == 'addtoindex') {
+                    $mform->setDefault('indexoptions['.$element.']', $value);
+                }
+
+                // If the element is accessstudents it needs to be placed in the access options group.
+                if ($element == 'accessstudents') {
+                    $mform->setDefault('accessoptions['.$element.']', $value);
+                }
+
+                $mform->setDefault($element, $value);
+            }
+        }
+        
+        $hassettings = true;
+    }
+
+    /**
      * Hook to allow report score and link to be displayed beside a submission.
      *
      * @param array $linkarray contains all relevant information to display a report score and link to cloud viewer.
@@ -858,78 +949,12 @@ class plagiarism_plugin_turnitinsim extends plagiarism_plugin {
  */
 function plagiarism_turnitinsim_coursemodule_standard_elements($formwrapper, $mform) {
     $context = context_course::instance($formwrapper->get_course()->id);
-    $modulename = isset($formwrapper->get_current()->modulename) ? 'mod_'.$formwrapper->get_current()->modulename : '';
-    $canconfigureplugin = false;
 
-    $cmid = optional_param('update', 0, PARAM_INT);
-
-    $location = ($context == context_system::instance()) ? 'defaults' : 'module';
-
-    // Get whether plugin is enabled for this module.
-    $moduletiienabled = empty($modulename) ? "0" : get_config('plagiarism_turnitinsim',
-        'turnitinmodenabled'.substr($modulename, 4));
-
-    if ($location === 'module') {
-        // Exit if Turnitin is not being used for this activity type and location is not default.
-        if (empty($moduletiienabled)) {
-            return;
-        }
-
-        // Course ID is only passed in on new module - if updating then get it from module id.
-        $courseid = optional_param('course', 0, PARAM_INT);
-        $id = optional_param('id', 0, PARAM_INT);
-
-        if (empty($courseid)) {
-            $checkcourse = (!empty($cmid)) ? $cmid : $id;
-            $course = get_coursemodule_from_id('', $checkcourse);
-
-            // If it is still empty, return to avoid an error.
-            if (empty($course)) {
-                return;
-            }
-
-            $courseid = $course->course;
-        }
-
-        // Exit if this user does not have permissions to configure the plugin.
-        if (has_capability('plagiarism/turnitinsim:enable', context_course::instance($courseid))) {
-            $canconfigureplugin = true;
-        }
-    } else {
-        $canconfigureplugin = true;
-    }
-
-    $form = new plagiarism_turnitinsim_settings();
-    $form->add_settings_to_module($mform, $canconfigureplugin, $location, $modulename);
-
-    if ($modsettings = (new plagiarism_plugin_turnitinsim())->get_settings( $cmid )) {
-
-        // Set the default value for each option as the value we have stored.
-        foreach ($modsettings as $element => $value) {
-
-            // If the element name starts with exclude it needs to be placed in the exclude options group.
-            if ( substr($element, 0, 7) == 'exclude' ) {
-                $mform->setDefault('excludeoptions['.$element.']', $value);
-            }
-
-            // If the element name starts with reportgen it needs to be placed in the report gen options group.
-            if ( substr($element, 0, 9) == 'reportgen' ) {
-                $mform->setDefault('reportgenoptions['.$element.']', $value);
-            }
-
-            // If the element is addtoindex it needs to be placed in the index options group.
-            if ($element == 'addtoindex') {
-                $mform->setDefault('indexoptions['.$element.']', $value);
-            }
-
-            // If the element is accessstudents it needs to be placed in the access options group.
-            if ($element == 'accessstudents') {
-                $mform->setDefault('accessoptions['.$element.']', $value);
-            }
-
-            $mform->setDefault($element, $value);
-        }
-    }
+    (new plagiarism_plugin_turnitinsim())->add_elements_to_settings_form(
+        $mform,
+        $context,
+        isset($formwrapper->get_current()->modulename) ? 'mod_'.$formwrapper->get_current()->modulename : ''
+    );
 }
 
 /**


### PR DESCRIPTION
Resolves #180 

The default settings page is broken because it is trying to find information about the current module. If you're configuring default settings, there is no current module.
To fix this we can use existing logic to figure out the location the settings form is being added.