### PR TITLE
Removing deprecated download_as_dataformat

### DIFF
--- a/dbexport.php
+++ b/dbexport.php
@@ -26,7 +26,6 @@
 // Require libs.
 require_once(dirname(dirname(dirname(__FILE__))).'/config.php');
 require_once($CFG->libdir.'/adminlib.php');
-require_once($CFG->libdir.'/dataformatlib.php');
 require_once( __DIR__ . '/utilities/handle_deprecation.php' );
 
 // Restrict access to admins only.
@@ -68,7 +67,7 @@ if (!is_null($table)) {
         $data = $DB->get_records($table, null, 'id ASC');
 
         // Use Moodle's dataformatting functions to output the data in the desired format.
-        handle_deprecation::download_data($exportfile, $dataformat, array_keys($DB->get_columns($table)), $data);
+        \core\dataformat::download_data($exportfile, $dataformat, array_keys($DB->get_columns($table)), $data);
 
         exit;
 

--- a/utilities/handle_deprecation.php
+++ b/utilities/handle_deprecation.php
@@ -99,22 +99,6 @@ class handle_deprecation {
     }
 
     /**
-     * In Moodle 3.9, download_as_dataformat() was deprecated and \core\dataformat::download_data() was introduced.
-     * This method handles our support for multiple Moodle versions.
-     *
-     * @param string $exportfile The name of the file to download.
-     * @param string $dataformat The format of the file.
-     * @param array $columns The names of the columns.
-     * @param string $data The data to download.
-     */
-    public static function download_data($exportfile, $dataformat, $columns, $data) {
-        global $CFG;
-
-        $CFG->branch >= 39 ? \core\dataformat::download_data($exportfile, $dataformat, $columns, $data)
-            : download_as_dataformat($exportfile, $dataformat, $columns, $data);
-    }
-
-    /**
      * In Moodle 3.10, Moodle switched to use PHPUnit 8.5 which contains deprecations for some assertions.
      * assertContains was deprecated in favour of the newer assertStringContainsString. (PHPUnit 7.5)
      * This method handles our support for Moodle versions that use PHPUnit 6.5. (Moodle 3.5 and 3.6)


### PR DESCRIPTION
dataformatlib has now been completely removed from core. We no longer need to handle deprecation and check the Moodle version as dataformatlib has been deprecated on all supported versions.