### PR TITLE
Updating name of collapsing header

### DIFF
--- a/classes/settings.class.php
+++ b/classes/settings.class.php
@@ -59,7 +59,7 @@ class plagiarism_turnitinsim_settings {
         global $PAGE;
 
         if ($context == 'module') {
-            $mform->addElement('header', 'plugin_header', get_string('turnitinpluginsettings', 'plagiarism_turnitinsim'));
+            $mform->addElement('header', 'turnitinsim_plugin_header', get_string('turnitinpluginsettings', 'plagiarism_turnitinsim'));
         }
 
         // Require JS modules.


### PR DESCRIPTION
The name 'plugin_header' is used for both PP and IP plugins. This means that if both plugins are installed, clicking the collapsing header to show the settings for one plugin will cause the settings for both plugins to be shown. We can fix this by giving each header a unique name.