### PR TITLE
Add namespace for mod_quiz

### DIFF
--- a/classes/submission.class.php
+++ b/classes/submission.class.php
@@ -558,7 +558,14 @@ class plagiarism_turnitinsim_submission {
                 }
 
                 // Queue each answer to a question.
-                $attempt = mod_quiz\quiz_attempt::create($this->getitemid());
+                // Namespace was changed in Moodle 4.2.
+                // TODO: We can delete the else block here when we no longer support Moodle 4.1
+                if ($CFG->version >= 2023042411) {
+                    $attempt = mod_quiz\quiz_attempt::create($this->getitemid());
+                }
+                else {
+                    $attempt = quiz_attempt::create($this->getitemid());
+                }
                 foreach ($attempt->get_slots() as $slot) {
                     $qa = $attempt->get_question_attempt($slot);
                     if ($this->getidentifier() == sha1($qa->get_response_summary())) {

--- a/classes/submission.class.php
+++ b/classes/submission.class.php
@@ -558,14 +558,12 @@ class plagiarism_turnitinsim_submission {
                 }
 
                 // Queue each answer to a question.
-                // Namespace was changed in Moodle 4.2.
-                // TODO: We can delete the else block here when we no longer support Moodle 4.1
-                if ($CFG->version >= 2023042411) {
-                    $attempt = mod_quiz\quiz_attempt::create($this->getitemid());
+                if (class_exists('\mod_quiz\quiz_attempt')) {
+                    $quizattemptclass = '\mod_quiz\quiz_attempt';
+                } else {
+                    $quizattemptclass = 'quiz_attempt';
                 }
-                else {
-                    $attempt = quiz_attempt::create($this->getitemid());
-                }
+                $attempt = $quizattemptclass::create($this->getitemid());
                 foreach ($attempt->get_slots() as $slot) {
                     $qa = $attempt->get_question_attempt($slot);
                     if ($this->getidentifier() == sha1($qa->get_response_summary())) {

--- a/classes/submission.class.php
+++ b/classes/submission.class.php
@@ -558,7 +558,7 @@ class plagiarism_turnitinsim_submission {
                 }
 
                 // Queue each answer to a question.
-                $attempt = quiz_attempt::create($this->getitemid());
+                $attempt = mod_quiz\quiz_attempt::create($this->getitemid());
                 foreach ($attempt->get_slots() as $slot) {
                     $qa = $attempt->get_question_attempt($slot);
                     if ($this->getidentifier() == sha1($qa->get_response_summary())) {

--- a/lib.php
+++ b/lib.php
@@ -821,7 +821,7 @@ class plagiarism_plugin_turnitinsim extends plagiarism_plugin {
         $submitter = new plagiarism_turnitinsim_user($eventdata['userid']);
 
         // Queue every question submitted in a quiz attempt.
-        $attempt = quiz_attempt::create($eventdata['objectid']);
+        $attempt = mod_quiz\quiz_attempt::create($eventdata['objectid']);
         $context = context_module::instance($attempt->get_cmid());
         foreach ($attempt->get_slots() as $slot) {
             $eventdata['other']['pathnamehashes'] = array();

--- a/lib.php
+++ b/lib.php
@@ -821,7 +821,12 @@ class plagiarism_plugin_turnitinsim extends plagiarism_plugin {
         $submitter = new plagiarism_turnitinsim_user($eventdata['userid']);
 
         // Queue every question submitted in a quiz attempt.
-        $attempt = mod_quiz\quiz_attempt::create($eventdata['objectid']);
+        if (class_exists('\mod_quiz\quiz_attempt')) {
+           $quizattemptclass = '\mod_quiz\quiz_attempt';
+        } else {
+            $quizattemptclass = 'quiz_attempt';
+        }
+        $attempt = $quizattemptclass::create($eventdata['objectid']);
         $context = context_module::instance($attempt->get_cmid());
         foreach ($attempt->get_slots() as $slot) {
             $eventdata['other']['pathnamehashes'] = array();


### PR DESCRIPTION
We should now be referring to the quiz_attempt class via the mod_quiz namespace. This namespace change was done in 3.9 so is valid in all versions we support.