### PR TITLE
Don't reuse TCA submissionid

### DIFF
--- a/classes/task.class.php
+++ b/classes/task.class.php
@@ -121,6 +121,7 @@ class plagiarism_turnitinsim_task {
             if ($tssubmission->getstatus() == TURNITINSIM_SUBMISSION_STATUS_QUEUED) {
                 $tssubmission->create_submission_in_turnitin();
 
+                // TII ID will only exist if submission has been created successfully
                 if (!empty($tssubmission->getturnitinid())) {
                     $tssubmission->upload_submission_to_turnitin();
 

--- a/classes/task.class.php
+++ b/classes/task.class.php
@@ -120,13 +120,13 @@ class plagiarism_turnitinsim_task {
 
             if ($tssubmission->getstatus() == TURNITINSIM_SUBMISSION_STATUS_QUEUED) {
                 $tssubmission->create_submission_in_turnitin();
+            }
 
-                if (tssubmission->getstatus() == TURNITINSIM_HTTP_CREATED) {
-                    $tssubmission->upload_submission_to_turnitin();
+            if ($tssubmission->getstatus() == TURNITINSIM_SUBMISSION_STATUS_CREATED && !empty($tssubmission->getturnitinid())) {
+                $tssubmission->upload_submission_to_turnitin();
 
-                    // Set the time for the report to be generated.
-                    $tssubmission->calculate_generation_time();
-                }
+                // Set the time for the report to be generated.
+                $tssubmission->calculate_generation_time();
             }
 
             $tssubmission->update();

--- a/classes/task.class.php
+++ b/classes/task.class.php
@@ -118,16 +118,11 @@ class plagiarism_turnitinsim_task {
                 continue;
             }
 
-            if ($tssubmission->getstatus() == TURNITINSIM_SUBMISSION_STATUS_QUEUED) {
+            if ($tssubmission->getstatus() == TURNITINSIM_SUBMISSION_STATUS_QUEUED || $tssubmission->gettiiattempts() > 0) {
                 $tssubmission->create_submission_in_turnitin();
             }
 
             if (!empty($tssubmission->getturnitinid())) {
-                // If this is a retry, generate a new submissionid
-                if ($tssubmission->gettiiattempts() > 0) {
-                    $tssubmission->create_submission_in_turnitin();
-                }
-
                 $tssubmission->upload_submission_to_turnitin();
 
                 // Set the time for the report to be generated.

--- a/classes/task.class.php
+++ b/classes/task.class.php
@@ -120,13 +120,13 @@ class plagiarism_turnitinsim_task {
 
             if ($tssubmission->getstatus() == TURNITINSIM_SUBMISSION_STATUS_QUEUED) {
                 $tssubmission->create_submission_in_turnitin();
-            }
 
-            if (!empty($tssubmission->getturnitinid())) {
-                $tssubmission->upload_submission_to_turnitin();
+                if (tssubmission->getstatus() == TURNITINSIM_HTTP_CREATED) {
+                    $tssubmission->upload_submission_to_turnitin();
 
-                // Set the time for the report to be generated.
-                $tssubmission->calculate_generation_time();
+                    // Set the time for the report to be generated.
+                    $tssubmission->calculate_generation_time();
+                }
             }
 
             $tssubmission->update();

--- a/classes/task.class.php
+++ b/classes/task.class.php
@@ -132,8 +132,6 @@ class plagiarism_turnitinsim_task {
 
                 // Set the time for the report to be generated.
                 $tssubmission->calculate_generation_time();
-
-                mtrace(json_encode($tssubmission, JSON_PRETTY_PRINT));
             }
 
             $tssubmission->update();

--- a/classes/task.class.php
+++ b/classes/task.class.php
@@ -122,11 +122,18 @@ class plagiarism_turnitinsim_task {
                 $tssubmission->create_submission_in_turnitin();
             }
 
-            if ($tssubmission->getstatus() == TURNITINSIM_SUBMISSION_STATUS_CREATED && !empty($tssubmission->getturnitinid())) {
+            if (!empty($tssubmission->getturnitinid())) {
+                // If this is a retry, generate a new submissionid
+                if ($tssubmission->gettiiattempts() > 0) {
+                    $tssubmission->create_submission_in_turnitin();
+                }
+
                 $tssubmission->upload_submission_to_turnitin();
 
                 // Set the time for the report to be generated.
                 $tssubmission->calculate_generation_time();
+
+                mtrace(json_encode($tssubmission, JSON_PRETTY_PRINT));
             }
 
             $tssubmission->update();

--- a/classes/task.class.php
+++ b/classes/task.class.php
@@ -118,15 +118,15 @@ class plagiarism_turnitinsim_task {
                 continue;
             }
 
-            if ($tssubmission->getstatus() == TURNITINSIM_SUBMISSION_STATUS_QUEUED || $tssubmission->gettiiattempts() > 0) {
+            if ($tssubmission->getstatus() == TURNITINSIM_SUBMISSION_STATUS_QUEUED) {
                 $tssubmission->create_submission_in_turnitin();
-            }
 
-            if (!empty($tssubmission->getturnitinid())) {
-                $tssubmission->upload_submission_to_turnitin();
+                if (!empty($tssubmission->getturnitinid())) {
+                    $tssubmission->upload_submission_to_turnitin();
 
-                // Set the time for the report to be generated.
-                $tssubmission->calculate_generation_time();
+                    // Set the time for the report to be generated.
+                    $tssubmission->calculate_generation_time();
+                }
             }
 
             $tssubmission->update();


### PR DESCRIPTION
We are seeing orphaned submissions in TCA due to reusing the same submissionid to retry submissions.
We need to generate a new submissionid when retrying sending a submission.