### PR TITLE
Add check for cached module restore data

### DIFF
--- a/backup/moodle2/restore_plagiarism_turnitinsim_plugin.class.php
+++ b/backup/moodle2/restore_plagiarism_turnitinsim_plugin.class.php
@@ -112,6 +112,10 @@ class restore_plagiarism_turnitinsim_plugin extends restore_plagiarism_plugin {
     public function after_restore_module() {
         global $DB, $SESSION;
 
+        if (!isset($SESSION->tsrestore)) {
+            return;
+        }
+
         foreach ($SESSION->tsrestore as $data) {
             // Get new itemid for files.
             if ($data->type == TURNITINSIM_SUBMISSION_TYPE_FILE) {


### PR DESCRIPTION
In cases where we don't need to cache module data we are getting warnings about missing properties