### PR TITLE
Use quiz attempt id as simulated event's objectid for grader report

### DIFF
--- a/classes/quiz.class.php
+++ b/classes/quiz.class.php
@@ -133,6 +133,7 @@ class plagiarism_turnitinsim_quiz {
      * @throws dml_exception
      */
     public function create_submission_event_data($linkarray) {
+        global $DB;
         $cm = get_coursemodule_from_id('', $linkarray['cmid']);
 
         $eventdata = array();
@@ -140,7 +141,9 @@ class plagiarism_turnitinsim_quiz {
 
         $eventdata['eventtype'] = 'quiz_submitted';
         $eventdata['userid'] = $linkarray['userid'];
-        $eventdata['objectid'] = $linkarray['area'];
+
+        $quizattemptid = $DB->get_field('quiz_attempts', 'id', ['uniqueid' => $linkarray['area']]);
+        $eventdata['objectid'] = $quizattemptid;
 
         if (isset($linkarray['file'])) {
             $eventdata['other']['pathnamehashes'] = array($linkarray['file']->get_pathnamehash());

--- a/tests/classes/quiz.class_test.php
+++ b/tests/classes/quiz.class_test.php
@@ -230,6 +230,10 @@ class quiz_class_testcase extends advanced_testcase {
         $this->setUser($this->student1);
 
         $file = create_test_file(1, 1, 'mod_quiz', 'submissions');
+        // Create a question attempt, step and quiz attempt.
+        $questionattempt = $this->create_question_attempt();
+        $this->create_question_attempt_step($questionattempt->id);
+        $quizattempt = $this->create_quiz_attempt($questionattempt->questionusageid);
 
         // Create dummy link array data.
         $linkarray = array(
@@ -247,7 +251,7 @@ class quiz_class_testcase extends advanced_testcase {
         $this->assertEquals($cm->id, $response['contextinstanceid']);
         $this->assertEquals($this->student1->id, $response['userid']);
         $this->assertEquals(array($file->get_pathnamehash()), $response['other']['pathnamehashes']);
-        $this->assertEquals($linkarray['area'], $response['objectid']);
+        $this->assertEquals($quizattempt->id, $response['objectid']);
         $this->assertEquals($this->student1->id, $response['relateduserid']);
         $this->assertEquals('quiz', $response['other']['modulename']);
     }
@@ -277,7 +281,7 @@ class quiz_class_testcase extends advanced_testcase {
         // Create a question attempt, step and quiz attempt.
         $questionattempt = $this->create_question_attempt();
         $this->create_question_attempt_step($questionattempt->id);
-        $this->create_quiz_attempt($questionattempt->questionusageid);
+        $quizattempt = $this->create_quiz_attempt($questionattempt->questionusageid);
 
         // Create dummy link array data.
         $linkarray = array(
@@ -293,7 +297,7 @@ class quiz_class_testcase extends advanced_testcase {
         $this->assertEquals('quiz_submitted', $response['eventtype']);
         $this->assertEquals($cm->id, $response['contextinstanceid']);
         $this->assertEquals($this->student1->id, $response['userid']);
-        $this->assertEquals($linkarray['area'], $response['objectid']);
+        $this->assertEquals($quizattempt->id, $response['objectid']);
         $this->assertEquals($this->student1->id, $response['relateduserid']);
         $this->assertEquals('quiz', $response['other']['modulename']);
     }


### PR DESCRIPTION
The function `create_submission_event_data()` creates simulated event data to pass to the submission handler, when it is called as part of the grader report.

For quizzes, it sets the simulated event's objectid to `$linkarray['area']`, which is the question attempt id (coming from Moodle core code's `formulation_and_controls()` function).

But the quiz submission handler is meant to receive an instance of \mod_quiz\event\attempt_submitted, in which the "objectid" field is the *quiz* attempt ID.