### PR TITLE
Showing forum eula when accessstudents=false

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -363,10 +363,13 @@ class plagiarism_plugin_turnitinsim extends plagiarism_plugin {
             // Render a resubmit link for instructors if necessary.
             $resubmitlink = ($instructor && $showresubmitlink) ? $this->render_resubmit_link($submission->getid()) : '';
 
-            // Output rendered status and resubmission link if applicable.
+            // Output rendered status, eula prompt, and resubmission link if applicable.
+            $towrite = $eulaconfirm ?? '';
             if ($instructor || (!$instructor && $plagiarismsettings->accessstudents)) {
-                $output .= html_writer::tag('div', $eulaconfirm . $turnitinicon . $status . $resubmitlink,
-                    array('class' => 'turnitinsim_status submission_' . $submissionid));
+                $towrite .= $turnitinicon . $status . $resubmitlink;
+            }
+            if (!empty($towrite)) {
+                $output .= html_writer::tag('div', $towrite, ['class' => 'turnitinsim_status submission_' . $submissionid]);
             }
         }
 


### PR DESCRIPTION
The eula prompt currently does not show in forums if the box "Allow Students to View Similarity Reports" is not ticked. This is because we use the same flow to display both the similarity score and the eula prompt in forums.
This PR breaks up the logic so that we display the eula prompt separately from the similarity score.