### PR TITLE
Remove logic for displaying multiple eula prompts

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -449,12 +449,9 @@ class plagiarism_plugin_turnitinsim extends plagiarism_plugin {
         global $CFG, $PAGE, $USER;
 
         // Avoid printing the EULA acceptance box more than once.
-        // This needs to be shown twice for a text submission as it exists in the dom twice.
         // Allowed for unit testing otherwise only the first test that calls this would work.
         static $disclosurecount = 1;
-        if (($submissiontype == 'file' && $disclosurecount === 1) ||
-            ($submissiontype == 'content' && $disclosurecount <= 2) ||
-            PHPUNIT_TEST) {
+        if ($disclosurecount === 1 || PHPUNIT_TEST) {
             $disclosurecount++;
 
             // Return empty output if the plugin is not being used.


### PR DESCRIPTION
Since fixing the eula prompts for forum posts, we are seeing the 2 most recent posts in a forum show the eula prompt. This should only be displayed once. I believe the existing logic to calculate the number of eula prompts is unnecessary and we should only be doing this once.