### PR TITLE
Improve handling of course modules in privacy provider unit test #220

### DIFF
--- a/tests/privacy/provider_test.php
+++ b/tests/privacy/provider_test.php
@@ -104,10 +104,9 @@ class plagiarism_turnitinsim_privacy_provider_testcase extends advanced_testcase
         $this->resetAfterTest();
 
         // Set the cm to the correct one for our submission.
-        $cms = $DB->get_records('course_modules');
-        $cm = reset($cms);
         $submissions = $DB->get_records('plagiarism_turnitinsim_sub');
         $submission = reset($submissions);
+        $cm = get_coursemodule_from_id('assign', $submission->cm);
 
         $update = new stdClass();
         $update->id = $submission->id;


### PR DESCRIPTION
Fixes #220 

Before this patch, if you have both this plugin and [OU blog](https://github.com/moodleou/moodle-mod_oublog) installed this test will fail because OU blog creates a site course module on install. 