### PR TITLE
Set events internal flag to true

### DIFF
--- a/db/events.php
+++ b/db/events.php
@@ -28,34 +28,42 @@ defined('MOODLE_INTERNAL') || die();
 $observers = array (
     array(
         'eventname' => '\assignsubmission_file\event\assessable_uploaded',
-        'callback'  => 'plagiarism_turnitinsim_observer::assignsubmission_file_uploaded'
+        'callback'  => 'plagiarism_turnitinsim_observer::assignsubmission_file_uploaded',
+        'internal'  => true
     ),
     array(
         'eventname' => '\assignsubmission_onlinetext\event\assessable_uploaded',
-        'callback'  => 'plagiarism_turnitinsim_observer::assignsubmission_onlinetext_uploaded'
+        'callback'  => 'plagiarism_turnitinsim_observer::assignsubmission_onlinetext_uploaded',
+        'internal'  => true
     ),
     array(
         'eventname' => '\mod_assign\event\assessable_submitted',
-        'callback'  => 'plagiarism_turnitinsim_observer::assignsubmission_submitted'
+        'callback'  => 'plagiarism_turnitinsim_observer::assignsubmission_submitted',
+        'internal'  => true
     ),
     array(
         'eventname' => '\mod_workshop\event\assessable_uploaded',
-        'callback'  => 'plagiarism_turnitinsim_observer::workshop_assessable_uploaded'
+        'callback'  => 'plagiarism_turnitinsim_observer::workshop_assessable_uploaded',
+        'internal'  => true
     ),
     array(
         'eventname' => '\mod_forum\event\assessable_uploaded',
-        'callback'  => 'plagiarism_turnitinsim_observer::forum_assessable_uploaded'
+        'callback'  => 'plagiarism_turnitinsim_observer::forum_assessable_uploaded',
+        'internal'  => true
     ),
     array(
         'eventname' => '\mod_quiz\event\attempt_submitted',
-        'callback' => 'plagiarism_turnitinsim_observer::quiz_submitted'
+        'callback' => 'plagiarism_turnitinsim_observer::quiz_submitted',
+        'internal'  => true
     ),
     array(
         'eventname' => '\core\event\course_module_updated',
-        'callback'  => 'plagiarism_turnitinsim_observer::module_updated'
+        'callback'  => 'plagiarism_turnitinsim_observer::module_updated',
+        'internal'  => true
     ),
     array(
         'eventname' => '\core\event\course_module_deleted',
-        'callback'  => 'plagiarism_turnitinsim_observer::course_module_deleted'
+        'callback'  => 'plagiarism_turnitinsim_observer::course_module_deleted',
+        'internal'  => true
     ),
 );


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk configuration-only change that marks existing event observers as `internal`, affecting only how Moodle categorizes/dispatches these events without changing observer callbacks.
> 
> **Overview**
> Sets `internal => true` on all `plagiarism_turnitinsim` event observer registrations in `db/events.php` (assign/workshop/forum/quiz and course module update/delete events).
> 
> No observer callbacks or event list changes; this is a metadata/config update to treat these observers as internal.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ede0c42bca8b41dc4430e45e09db1ff06a115be1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->