### PR TITLE
Update report score colours

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -277,7 +277,17 @@ class plagiarism_plugin_turnitinsim extends plagiarism_plugin {
                     case TURNITINSIM_SUBMISSION_STATUS_COMPLETE:
                         $score = $submission->getoverallscore() . '%';
                         $submissionid = $submission->getid();
-                        $orcolour = ' turnitinsim_or_score_colour_' . round($submission->getoverallscore(), -1);
+                        $score = $submission->getoverallscore();
+                        $csssuffix = match (true) {
+                            $score === null || $score === '' => '',
+                            $score <= 24  => '0',
+                            $score <= 49  => '25',
+                            $score <= 74  => '50',
+                            $score <= 99  => '75',
+                            $score == 100 => '100',
+                            default       => ''
+                        };
+                        $orcolour = ' turnitinsim_or_score_colour_' . $csssuffix;
                         $status = html_writer::tag('div', $score, array('class' => 'turnitinsim_or_score' . $orcolour));
                         break;
 

--- a/styles.css
+++ b/styles.css
@@ -82,55 +82,12 @@
 }
 
 /* Define OR score colours */
-.turnitinsim_links .turnitinsim_status .turnitinsim_or_score_colour_0 {
-    background: #3552b7;
-    color: #fff;
-}
-
-.turnitinsim_links .turnitinsim_status .turnitinsim_or_score_colour_10 {
-    background: #617b8d;
-    color: #fff;
-}
-
-.turnitinsim_links .turnitinsim_status .turnitinsim_or_score_colour_20 {
-    background: #a1b556;
-}
-
-.turnitinsim_links .turnitinsim_status .turnitinsim_or_score_colour_30 {
-    background: #dae235;
-}
-
-.turnitinsim_links .turnitinsim_status .turnitinsim_or_score_colour_40 {
-    background: #edac28;
-}
-
-.turnitinsim_links .turnitinsim_status .turnitinsim_or_score_colour_50 {
-    background: #edd42f;
-}
-
-.turnitinsim_links .turnitinsim_status .turnitinsim_or_score_colour_60 {
-    background: #ecad28;
-}
-
-.turnitinsim_links .turnitinsim_status .turnitinsim_or_score_colour_70 {
-    background: #e15a21;
-    color: #fff;
-}
-
-.turnitinsim_links .turnitinsim_status .turnitinsim_or_score_colour_80 {
-    background: #e05a21;
-    color: #fff;
-}
-
-.turnitinsim_links .turnitinsim_status .turnitinsim_or_score_colour_90 {
-    background: #dc4321;
-    color: #fff;
-}
-
-.turnitinsim_links .turnitinsim_status .turnitinsim_or_score_colour_100 {
-    background: #db4221;
-    color: #fff;
-}
+.turnitinsim_links .turnitinsim_status .turnitinsim_or_score_colour_ { background: #999999; color:#000000; }
+.turnitinsim_links .turnitinsim_status .turnitinsim_or_score_colour_0 { background: #4ea3f0; color:#FFFFFF; }
+.turnitinsim_links .turnitinsim_status .turnitinsim_or_score_colour_25 { background: #70c30f; }
+.turnitinsim_links .turnitinsim_status .turnitinsim_or_score_colour_50 { background: #ffe225; }
+.turnitinsim_links .turnitinsim_status .turnitinsim_or_score_colour_75 { background: #ffa400; }
+.turnitinsim_links .turnitinsim_status .turnitinsim_or_score_colour_100 { background: #f03a3a; color:#FFFFFF; }
 
 .form-group .form-inline .form-check-inline.form-check-label.fitem.turnitinsim_settings_radio {
     margin-right: 0;


### PR DESCRIPTION
This PR updates the css colours we use to display each similarity score range. 0-25 is blue, 25-50 is green, etc. This brings the plugin in line with the updated branding as published here: https://guides.turnitin.com/hc/en-us/articles/23435833938701-Understanding-the-similarity-score