### PR TITLE
Cleaning up unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .idea/*
-tests/behat
+.phpunit.result.cache

--- a/classes/eula.class.php
+++ b/classes/eula.class.php
@@ -57,7 +57,7 @@ class plagiarism_turnitinsim_eula {
         // Make request to get the latest EULA version.
         try {
             $lang = $this->tsrequest->get_language();
-            $langcode = $lang->localecode;
+            $langcode = isset($lang) ? $lang->localecode : 'en-US';
             $endpoint = TURNITINSIM_ENDPOINT_GET_LATEST_EULA."?lang=".$langcode;
             $response = $this->tsrequest->send_request($endpoint, json_encode(array()), 'GET');
             $response = json_decode($response);

--- a/classes/request.class.php
+++ b/classes/request.class.php
@@ -269,7 +269,9 @@ class plagiarism_turnitinsim_request {
         $this->set_headers();
 
         $response = $this->send_request(TURNITINSIM_ENDPOINT_WEBHOOKS, json_encode(array()), 'GET');
-        $responsedata = json_decode($response);
+        if (isset($response)) {
+            $responsedata = json_decode($response);
+        }
 
         if (isset($responsedata->httpstatus) && $responsedata->httpstatus === TURNITINSIM_HTTP_OK) {
             $data["connection_status"] = TURNITINSIM_HTTP_OK;

--- a/lib.php
+++ b/lib.php
@@ -197,7 +197,7 @@ class plagiarism_plugin_turnitinsim extends plagiarism_plugin {
 
         // Return empty output if the plugin is not being used.
         if (!$ispluginactive) {
-            return $output;
+            return '';
         }
 
         // Create module object.
@@ -222,7 +222,7 @@ class plagiarism_plugin_turnitinsim extends plagiarism_plugin {
         $plagiarismfile = plagiarism_turnitinsim_submission::get_submission_details($linkarray);
         // If this is a preview quiz submission there will be no record in turnitinsim_sub, so don't display any links
         if (empty($plagiarismfile)) {
-            return;
+            return html_writer::tag('div', $output, array('class' => 'turnitinsim_links'));
         }
 
         // Display cv link and OR score or status.

--- a/lib.php
+++ b/lib.php
@@ -288,7 +288,7 @@ class plagiarism_plugin_turnitinsim extends plagiarism_plugin {
                             default       => ''
                         };
                         $orcolour = ' turnitinsim_or_score_colour_' . $csssuffix;
-                        $status = html_writer::tag('div', $score, array('class' => 'turnitinsim_or_score' . $orcolour));
+                        $status = html_writer::tag('div', $score.'%', array('class' => 'turnitinsim_or_score' . $orcolour));
                         break;
 
                     case TURNITINSIM_SUBMISSION_STATUS_EULA_NOT_ACCEPTED:

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="../../lib/phpunit/bootstrap.php">
+    <testsuites>
+        <testsuite name="plagiarism_turnitinsim">
+            <directory suffix="test.php">tests</directory>
+            <exclude>tests/behat</exclude>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/classes/assign_class_test.php
+++ b/tests/classes/assign_class_test.php
@@ -32,12 +32,18 @@ require_once($CFG->dirroot . '/plagiarism/turnitinsim/tests/utilities.php');
 /**
  * Tests for assign module class for plagiarism_turnitinsim component.
  */
-class assign_class_testcase extends advanced_testcase {
+class assign_class_test extends advanced_testcase {
 
     /**
      * This is text content for unit testing a text submission.
      */
     const TEST_ASSIGN_TEXT = 'This is text content for unit testing a text submission.';
+
+		private $student1;
+		private $student2;
+		private $course;
+		private $instructor;
+		private $instructorrole;
 
     /**
      * Set config for use in the tests.

--- a/tests/classes/callback_class_test.php
+++ b/tests/classes/callback_class_test.php
@@ -34,7 +34,7 @@ require_once($CFG->dirroot . '/plagiarism/turnitinsim/tests/utilities.php');
 /**
  * Tests for Turnitin Integrity submission class.
  */
-class callback_class_testcase extends advanced_testcase {
+class callback_class_test extends advanced_testcase {
 
     /**
      * Set config for use in the tests.
@@ -62,7 +62,7 @@ class callback_class_testcase extends advanced_testcase {
 
         // Mock API request class.
         $tsrequest = $this->getMockBuilder(plagiarism_turnitinsim_request::class)
-            ->setMethods(['send_request'])
+            ->onlyMethods(['send_request'])
             ->setConstructorArgs([TURNITINSIM_ENDPOINT_GET_WEBHOOK])
             ->getMock();
 
@@ -88,7 +88,7 @@ class callback_class_testcase extends advanced_testcase {
 
         // Mock API request class.
         $tsrequest = $this->getMockBuilder(plagiarism_turnitinsim_request::class)
-            ->setMethods(['send_request'])
+            ->onlyMethods(['send_request'])
             ->setConstructorArgs([TURNITINSIM_ENDPOINT_GET_WEBHOOK])
             ->getMock();
 
@@ -117,7 +117,7 @@ class callback_class_testcase extends advanced_testcase {
 
         // Mock API request class.
         $tsrequest = $this->getMockBuilder(plagiarism_turnitinsim_request::class)
-            ->setMethods(['send_request'])
+            ->onlyMethods(['send_request'])
             ->setConstructorArgs([TURNITINSIM_ENDPOINT_GET_WEBHOOK])
             ->getMock();
 
@@ -146,7 +146,7 @@ class callback_class_testcase extends advanced_testcase {
 
         // Mock API request class.
         $tsrequest = $this->getMockBuilder(plagiarism_turnitinsim_request::class)
-            ->setMethods(['send_request'])
+            ->onlyMethods(['send_request'])
             ->setConstructorArgs([TURNITINSIM_ENDPOINT_GET_WEBHOOK])
             ->getMock();
 
@@ -175,7 +175,7 @@ class callback_class_testcase extends advanced_testcase {
 
         // Mock API request class.
         $tsrequest = $this->getMockBuilder(plagiarism_turnitinsim_request::class)
-            ->setMethods(['send_request'])
+            ->onlyMethods(['send_request'])
             ->setConstructorArgs([TURNITINSIM_ENDPOINT_WEBHOOKS])
             ->getMock();
 
@@ -213,7 +213,7 @@ class callback_class_testcase extends advanced_testcase {
 
         // Mock API request class.
         $tsrequest = $this->getMockBuilder(plagiarism_turnitinsim_request::class)
-            ->setMethods(['send_request'])
+            ->onlyMethods(['send_request'])
             ->setConstructorArgs([TURNITINSIM_ENDPOINT_WEBHOOKS])
             ->getMock();
 
@@ -238,7 +238,7 @@ class callback_class_testcase extends advanced_testcase {
 
         // Mock API request class.
         $tsrequest = $this->getMockBuilder(plagiarism_turnitinsim_request::class)
-            ->setMethods(['send_request'])
+            ->onlyMethods(['send_request'])
             ->setConstructorArgs([TURNITINSIM_ENDPOINT_WEBHOOKS])
             ->getMock();
 
@@ -267,7 +267,7 @@ class callback_class_testcase extends advanced_testcase {
 
         // Mock API request class.
         $tsrequest = $this->getMockBuilder(plagiarism_turnitinsim_request::class)
-            ->setMethods(['send_request'])
+            ->onlyMethods(['send_request'])
             ->setConstructorArgs([TURNITINSIM_ENDPOINT_WEBHOOKS])
             ->getMock();
 
@@ -298,7 +298,7 @@ class callback_class_testcase extends advanced_testcase {
 
         // Mock API request class.
         $tsrequest = $this->getMockBuilder(plagiarism_turnitinsim_request::class)
-            ->setMethods(['send_request'])
+            ->onlyMethods(['send_request'])
             ->setConstructorArgs([TURNITINSIM_ENDPOINT_GET_WEBHOOK])
             ->getMock();
 
@@ -324,7 +324,7 @@ class callback_class_testcase extends advanced_testcase {
 
         // Mock API request class.
         $tsrequest = $this->getMockBuilder(plagiarism_turnitinsim_request::class)
-            ->setMethods(['send_request'])
+            ->onlyMethods(['send_request'])
             ->setConstructorArgs([TURNITINSIM_ENDPOINT_WEBHOOKS])
             ->getMock();
 
@@ -353,7 +353,7 @@ class callback_class_testcase extends advanced_testcase {
 
         // Mock API request class.
         $tsrequest = $this->getMockBuilder(plagiarism_turnitinsim_request::class)
-            ->setMethods(['send_request'])
+            ->onlyMethods(['send_request'])
             ->setConstructorArgs([TURNITINSIM_ENDPOINT_WEBHOOKS])
             ->getMock();
 

--- a/tests/classes/defaults_form_class_test.php
+++ b/tests/classes/defaults_form_class_test.php
@@ -32,7 +32,7 @@ require_once($CFG->dirroot . '/plagiarism/turnitinsim/utilities/handle_deprecati
 /**
  * Tests for default settings form.
  */
-class defaultsform_class_testcase extends advanced_testcase {
+class defaults_form_class_test extends advanced_testcase {
 
     /**
      * Set config for use in the tests.

--- a/tests/classes/eula_class_test.php
+++ b/tests/classes/eula_class_test.php
@@ -33,7 +33,12 @@ require_once($CFG->dirroot . '/plagiarism/turnitinsim/tests/turnitinsim_generato
 /**
  * Tests for Turnitin Integrity submission class.
  */
-class eula_class_testcase extends advanced_testcase {
+class eula_class_test extends advanced_testcase {
+
+		private $turnitinsim_generator;
+		private $course;
+		private $student;
+		private $instructor;
 
     /**
      * Set config for use in the tests.
@@ -60,7 +65,7 @@ class eula_class_testcase extends advanced_testcase {
 
         // Mock API request class.
         $tsrequest = $this->getMockBuilder(plagiarism_turnitinsim_request::class)
-            ->setMethods(['send_request'])
+            ->onlyMethods(['send_request'])
             ->setConstructorArgs([TURNITINSIM_ENDPOINT_GET_LATEST_EULA])
             ->getMock();
 
@@ -85,7 +90,7 @@ class eula_class_testcase extends advanced_testcase {
 
         // Mock API request class.
         $tsrequest = $this->getMockBuilder(plagiarism_turnitinsim_request::class)
-            ->setMethods(['send_request'])
+            ->onlyMethods(['send_request'])
             ->setConstructorArgs([TURNITINSIM_ENDPOINT_GET_LATEST_EULA])
             ->getMock();
 
@@ -113,7 +118,7 @@ class eula_class_testcase extends advanced_testcase {
 
         // Mock API request class.
         $tsrequest = $this->getMockBuilder(plagiarism_turnitinsim_request::class)
-            ->setMethods(['send_request'])
+            ->onlyMethods(['send_request'])
             ->setConstructorArgs([TURNITINSIM_ENDPOINT_GET_LATEST_EULA])
             ->getMock();
 
@@ -141,7 +146,7 @@ class eula_class_testcase extends advanced_testcase {
         set_config('turnitin_eula_version', 'v1beta', 'plagiarism_turnitinsim');
 
         // Create 3 submissions.
-        $this->turnitinsim_generator = new turnitinsim_generator();
+        $this->turnitinsim_generator = new turnitinsim_generator('turnitinsim_generator');
         $submission = $this->turnitinsim_generator->create_submission(3, TURNITINSIM_SUBMISSION_STATUS_EULA_NOT_ACCEPTED);
 
         $this->setUser($submission['student']);
@@ -232,20 +237,16 @@ class eula_class_testcase extends advanced_testcase {
 
         // Mock API request class.
         $tsrequest = $this->getMockBuilder(plagiarism_turnitinsim_request::class)
-            ->setMethods(['send_request'])
+            ->onlyMethods(['send_request'])
             ->setConstructorArgs([TURNITINSIM_ENDPOINT_GET_LATEST_EULA])
             ->getMock();
-
-        // Mock API send request method.
-        $tsrequest->expects($this->once())
-            ->method('send_request')
-            ->willReturn($response);
 
         $tseula = new plagiarism_turnitinsim_eula( $tsrequest );
         $result = $tseula->get_eula_status($cm->id, 'file', $this->student->id);
 
+        $eulaurl = get_config('plagiarism_turnitinsim', 'turnitin_eula_url');
         handle_deprecation::assertcontains($this,
-            get_string('eulalink', 'plagiarism_turnitinsim', '?lang=en-US'), $result['eula-confirm']);
+            get_string('eulalink', 'plagiarism_turnitinsim', $eulaurl), $result['eula-confirm']);
         handle_deprecation::assertcontains($this,
             get_string('submissiondisplayerror:eulanotaccepted_help', 'plagiarism_turnitinsim'), $result['eula-status']);
     }
@@ -308,20 +309,16 @@ class eula_class_testcase extends advanced_testcase {
 
         // Mock API request class.
         $tsrequest = $this->getMockBuilder(plagiarism_turnitinsim_request::class)
-            ->setMethods(['send_request'])
+            ->onlyMethods(['send_request'])
             ->setConstructorArgs([TURNITINSIM_ENDPOINT_GET_LATEST_EULA])
             ->getMock();
-
-        // Mock API send request method.
-        $tsrequest->expects($this->once())
-            ->method('send_request')
-            ->willReturn($response);
 
         $tseula = new plagiarism_turnitinsim_eula($tsrequest);
         $result = $tseula->get_eula_status($cm->id, 'file', $this->instructor->id);
 
+        $eulaurl = get_config('plagiarism_turnitinsim', 'turnitin_eula_url');
         handle_deprecation::assertcontains($this,
-            get_string('eulalink', 'plagiarism_turnitinsim', '?lang=en-US'), $result['eula-confirm']);
+            get_string('eulalink', 'plagiarism_turnitinsim', $eulaurl), $result['eula-confirm']);
         handle_deprecation::assertcontains($this,
             get_string('submissiondisplayerror:eulanotaccepted_help', 'plagiarism_turnitinsim'), $result['eula-status']);
     }

--- a/tests/classes/forum_class_test.php
+++ b/tests/classes/forum_class_test.php
@@ -32,12 +32,17 @@ require_once($CFG->dirroot . '/plagiarism/turnitinsim/tests/utilities.php');
 /**
  * Tests for forum module class for plagiarism_turnitinsim component.
  */
-class forum_class_testcase extends advanced_testcase {
+class forum_class_test extends advanced_testcase {
 
     /**
      * Sample text for testing a forum.
      */
     const TEST_FORUM_TEXT = 'This is a test forum post';
+
+		private $course;
+		private $instructor;
+		private $student1;
+		private $student2;
 
     /**
      * Set config for use in the tests.

--- a/tests/classes/group_class_test.php
+++ b/tests/classes/group_class_test.php
@@ -31,7 +31,10 @@ require_once($CFG->dirroot . '/plagiarism/turnitinsim/classes/group.class.php');
 /**
  * Tests for Turnitin Integrity group class.
  */
-class group_class_testcase extends advanced_testcase {
+class group_class_test extends advanced_testcase {
+
+		private $course;
+		private $student1;
 
     /**
      * Test that group constructor creates a turnitinid in the correct format.

--- a/tests/classes/logging_request_class_test.php
+++ b/tests/classes/logging_request_class_test.php
@@ -32,7 +32,7 @@ require_once($CFG->dirroot . '/plagiarism/turnitinsim/tests/utilities.php');
 /**
  * Tests for Turnitin Integrity submission class.
  */
-class logging_request_class_testcase extends advanced_testcase {
+class logging_request_class_test extends advanced_testcase {
 
 
     /**
@@ -52,7 +52,7 @@ class logging_request_class_testcase extends advanced_testcase {
 
         // Mock API request class.
         $tsrequest = $this->getMockBuilder(plagiarism_turnitinsim_request::class)
-            ->setMethods(['send_request'])
+            ->onlyMethods(['send_request'])
             ->getMock();
 
         // Mock API send request method.
@@ -76,7 +76,7 @@ class logging_request_class_testcase extends advanced_testcase {
 
         // Mock API request class.
         $tsrequest = $this->getMockBuilder(plagiarism_turnitinsim_request::class)
-            ->setMethods(['send_request'])
+            ->onlyMethods(['send_request'])
             ->getMock();
 
         // Mock API send request method.

--- a/tests/classes/quiz_class_test.php
+++ b/tests/classes/quiz_class_test.php
@@ -34,7 +34,10 @@ require_once($CFG->dirroot . '/mod/workshop/tests/fixtures/testable.php');
 /**
  * Tests for quiz module class for plagiarism_turnitinsim component
  */
-class quiz_class_testcase extends advanced_testcase {
+class quiz_class_test extends advanced_testcase {
+
+    private $student1;
+    private $student2;
 
     /**
      * Sample text used for unit testing a quiz.

--- a/tests/classes/request_class_test.php
+++ b/tests/classes/request_class_test.php
@@ -33,7 +33,7 @@ require_once($CFG->dirroot . '/plagiarism/turnitinsim/tests/utilities.php');
 /**
  * Tests for Turnitin Integrity submission class.
  */
-class request_class_testcase extends advanced_testcase {
+class request_class_test extends advanced_testcase {
 
     /**
      * Set config for use in the tests.
@@ -57,7 +57,7 @@ class request_class_testcase extends advanced_testcase {
 
         // Mock API request class.
         $tsrequest = $this->getMockBuilder(plagiarism_turnitinsim_request::class)
-            ->setMethods(['send_request'])
+            ->onlyMethods(['send_request'])
             ->setConstructorArgs([TURNITINSIM_ENDPOINT_WEBHOOKS])
             ->getMock();
 

--- a/tests/classes/settings_class_test.php
+++ b/tests/classes/settings_class_test.php
@@ -32,7 +32,7 @@ require_once($CFG->dirroot . '/plagiarism/turnitinsim/classes/settings.class.php
 /**
  * Tests for settings form.
  */
-class settings_class_testcase extends advanced_testcase {
+class settings_class_test extends advanced_testcase {
 
     /**
      * Set config for use in the tests.
@@ -130,7 +130,7 @@ class settings_class_testcase extends advanced_testcase {
 
         // Mock API request class.
         $tsrequest = $this->getMockBuilder(plagiarism_turnitinsim_request::class)
-            ->setMethods(['send_request'])
+            ->onlyMethods(['send_request'])
             ->setConstructorArgs([TURNITINSIM_ENDPOINT_GET_FEATURES_ENABLED])
             ->getMock();
 
@@ -155,7 +155,7 @@ class settings_class_testcase extends advanced_testcase {
 
         // Mock API request class.
         $tsrequest = $this->getMockBuilder(plagiarism_turnitinsim_request::class)
-            ->setMethods(['send_request'])
+            ->onlyMethods(['send_request'])
             ->setConstructorArgs([TURNITINSIM_ENDPOINT_GET_FEATURES_ENABLED])
             ->getMock();
 
@@ -183,7 +183,7 @@ class settings_class_testcase extends advanced_testcase {
 
         // Mock API request class.
         $tsrequest = $this->getMockBuilder(plagiarism_turnitinsim_request::class)
-            ->setMethods(['send_request'])
+            ->onlyMethods(['send_request'])
             ->setConstructorArgs([TURNITINSIM_ENDPOINT_GET_FEATURES_ENABLED])
             ->getMock();
 

--- a/tests/classes/setup_form_class_test.php
+++ b/tests/classes/setup_form_class_test.php
@@ -32,7 +32,7 @@ require_once($CFG->dirroot . '/plagiarism/turnitinsim/utilities/handle_deprecati
 /**
  * Tests for settings form.
  */
-class setupform_class_testcase extends advanced_testcase {
+class setup_form_class_test extends advanced_testcase {
 
     /**
      * Plugin enabled.

--- a/tests/classes/submission_class_test.php
+++ b/tests/classes/submission_class_test.php
@@ -33,7 +33,7 @@ require_once($CFG->dirroot . '/plagiarism/turnitinsim/utilities/handle_deprecati
 /**
  * Tests for Turnitin Integrity submission class.
  */
-class submission_class_testcase extends advanced_testcase {
+class submission_class_test extends advanced_testcase {
 
     /**
      * A valid submission ID.
@@ -54,6 +54,11 @@ class submission_class_testcase extends advanced_testcase {
      * Another sample error message.
      */
     const TEST_ERROR_MESSAGE_2 = 'Example error message 2.';
+
+		private $instructor;
+		private $student1;
+		private $student2;
+		private $course;
 
     /**
      * Set config for use in the tests.
@@ -493,7 +498,7 @@ class submission_class_testcase extends advanced_testcase {
 
         // Mock API request class.
         $tsrequest = $this->getMockBuilder(plagiarism_turnitinsim_request::class)
-            ->setMethods(['send_request'])
+            ->onlyMethods(['send_request'])
             ->setConstructorArgs([TURNITINSIM_ENDPOINT_CREATE_SUBMISSION])
             ->getMock();
 
@@ -531,7 +536,7 @@ class submission_class_testcase extends advanced_testcase {
 
         // Mock API request class.
         $tsrequest = $this->getMockBuilder(plagiarism_turnitinsim_request::class)
-            ->setMethods(['send_request'])
+            ->onlyMethods(['send_request'])
             ->setConstructorArgs([TURNITINSIM_ENDPOINT_CREATE_SUBMISSION])
             ->getMock();
 
@@ -593,7 +598,7 @@ class submission_class_testcase extends advanced_testcase {
 
         // Mock API create submission request class and send call.
         $tsrequest = $this->getMockBuilder(plagiarism_turnitinsim_request::class)
-            ->setMethods(['send_request'])
+            ->onlyMethods(['send_request'])
             ->getMock();
 
         // We must parse the expected response to get the submission id for the upload request.
@@ -651,7 +656,7 @@ class submission_class_testcase extends advanced_testcase {
 
         // Mock API update submission request class and send call.
         $tsrequest = $this->getMockBuilder(plagiarism_turnitinsim_request::class)
-            ->setMethods(['send_request'])
+            ->onlyMethods(['send_request'])
             ->getMock();
 
         // We must parse the expected response to get the submission id for the upload request.
@@ -725,7 +730,7 @@ class submission_class_testcase extends advanced_testcase {
 
         // Mock API create submission request class and send call.
         $tsrequest = $this->getMockBuilder(plagiarism_turnitinsim_request::class)
-            ->setMethods(['send_request'])
+            ->onlyMethods(['send_request'])
             ->getMock();
 
         // We must parse the expected response to get the submission id for the upload request.
@@ -797,7 +802,7 @@ class submission_class_testcase extends advanced_testcase {
 
         // Mock API create submission request class and send call.
         $tsrequest = $this->getMockBuilder(plagiarism_turnitinsim_request::class)
-            ->setMethods(['send_request'])
+            ->onlyMethods(['send_request'])
             ->getMock();
 
         // Add submission ID to endpoint.
@@ -873,7 +878,7 @@ class submission_class_testcase extends advanced_testcase {
 
         // Mock API create submission request class and send call.
         $tsrequest = $this->getMockBuilder(plagiarism_turnitinsim_request::class)
-            ->setMethods(['send_request'])
+            ->onlyMethods(['send_request'])
             ->getMock();
 
         // Add submission ID to endpoint.
@@ -952,7 +957,7 @@ class submission_class_testcase extends advanced_testcase {
 
         // Mock API create submission request class and send call.
         $tsrequest = $this->getMockBuilder(plagiarism_turnitinsim_request::class)
-            ->setMethods(['send_request'])
+            ->onlyMethods(['send_request'])
             ->getMock();
 
         // Add submission ID to endpoint.
@@ -1029,7 +1034,7 @@ class submission_class_testcase extends advanced_testcase {
 
         // Mock API create submission request class and send call.
         $tsrequest = $this->getMockBuilder(plagiarism_turnitinsim_request::class)
-            ->setMethods(['send_request'])
+            ->onlyMethods(['send_request'])
             ->getMock();
 
         // Add submission ID to endpoint.
@@ -1105,7 +1110,7 @@ class submission_class_testcase extends advanced_testcase {
 
         // Mock API create submission request class and send call.
         $tsrequest = $this->getMockBuilder(plagiarism_turnitinsim_request::class)
-            ->setMethods(['send_request'])
+            ->onlyMethods(['send_request'])
             ->getMock();
 
         // Add submission ID to endpoint.
@@ -1181,7 +1186,7 @@ class submission_class_testcase extends advanced_testcase {
 
         // Mock API create submission request class and send call.
         $tsrequest = $this->getMockBuilder(plagiarism_turnitinsim_request::class)
-            ->setMethods(['send_request'])
+            ->onlyMethods(['send_request'])
             ->getMock();
 
         // Add submission ID to endpoint.
@@ -2035,7 +2040,7 @@ class submission_class_testcase extends advanced_testcase {
 
         // Mock API request class.
         $tsrequest = $this->getMockBuilder(plagiarism_turnitinsim_request::class)
-            ->setMethods(['send_request'])
+            ->onlyMethods(['send_request'])
             ->setConstructorArgs([TURNITINSIM_ENDPOINT_GET_SUBMISSION_INFO])
             ->getMock();
 
@@ -2079,7 +2084,7 @@ class submission_class_testcase extends advanced_testcase {
 
         // Mock API request class.
         $tsrequest = $this->getMockBuilder(plagiarism_turnitinsim_request::class)
-            ->setMethods(['send_request'])
+            ->onlyMethods(['send_request'])
             ->setConstructorArgs([TURNITINSIM_ENDPOINT_GET_SUBMISSION_INFO])
             ->getMock();
 
@@ -2135,7 +2140,7 @@ class submission_class_testcase extends advanced_testcase {
 
         // Mock API request class.
         $tsrequest = $this->getMockBuilder(plagiarism_turnitinsim_request::class)
-            ->setMethods(['send_request'])
+            ->onlyMethods(['send_request'])
             ->setConstructorArgs([TURNITINSIM_ENDPOINT_GET_SUBMISSION_INFO])
             ->getMock();
 
@@ -2291,7 +2296,7 @@ class submission_class_testcase extends advanced_testcase {
 
         // Mock API request class.
         $tsrequest = $this->getMockBuilder(plagiarism_turnitinsim_request::class)
-            ->setMethods(['send_request'])
+            ->onlyMethods(['send_request'])
             ->getMock();
 
         // Mock API send request method.

--- a/tests/classes/submission_class_test.php
+++ b/tests/classes/submission_class_test.php
@@ -191,6 +191,14 @@ class submission_class_test extends advanced_testcase {
         $tssubmission = new plagiarism_turnitinsim_submission();
         $tssubmission->setuserid($this->student1->id);
 
+        // Create assign module.
+        $record = new stdClass();
+        $record->course = $this->course;
+        $module = $this->getDataGenerator()->create_module('assign', $record);
+        // Get course module data.
+        $cm = get_coursemodule_from_instance('assign', $module->id);
+        $tssubmission->setcm($cm);
+
         // Build user entry and get Turnitin id.
         $userentry = $tssubmission->build_user_array_entry($this->student1);
         $tsuser = new plagiarism_turnitinsim_user($this->student1->id);

--- a/tests/classes/task_class_test.php
+++ b/tests/classes/task_class_test.php
@@ -31,7 +31,7 @@ require_once($CFG->dirroot . '/plagiarism/turnitinsim/classes/task.class.php');
 /**
  * Tests for Turnitin Integrity user class.
  */
-class task_class_testcase extends advanced_testcase {
+class task_class_test extends advanced_testcase {
 
     /**
      * An example API URL used for unit testing.

--- a/tests/classes/user_class_test.php
+++ b/tests/classes/user_class_test.php
@@ -31,7 +31,7 @@ require_once($CFG->dirroot . '/plagiarism/turnitinsim/classes/user.class.php');
 /**
  * Tests for Turnitin Integrity user class.
  */
-class user_class_testcase extends advanced_testcase {
+class user_class_test extends advanced_testcase {
 
     /**
      * Test that user constructor creates a turnitinid in the correct format.

--- a/tests/classes/workshop_class_test.php
+++ b/tests/classes/workshop_class_test.php
@@ -34,7 +34,7 @@ require_once($CFG->dirroot . '/mod/workshop/tests/fixtures/testable.php');
 /**
  * Tests for workshop module class for plagiarism_turnitinsim component
  */
-class workshop_class_testcase extends advanced_testcase {
+class workshop_class_test extends advanced_testcase {
 
     /**
      * Sample text used for unit testing a workshop.

--- a/tests/classes/workshop_class_test.php
+++ b/tests/classes/workshop_class_test.php
@@ -36,6 +36,9 @@ require_once($CFG->dirroot . '/mod/workshop/tests/fixtures/testable.php');
  */
 class workshop_class_test extends advanced_testcase {
 
+    protected $student1;
+    protected $student2;
+
     /**
      * Sample text used for unit testing a workshop.
      */

--- a/tests/lib_test.php
+++ b/tests/lib_test.php
@@ -34,7 +34,7 @@ require_once($CFG->dirroot . '/plagiarism/turnitinsim/tests/utilities.php');
 /**
  * Tests for lib methods.
  */
-class plagiarism_turnitinsim_lib_testcase extends advanced_testcase {
+class lib_test extends \advanced_testcase {
 
     /**
      * Sample eula version for unit testing.

--- a/tests/privacy/provider_test.php
+++ b/tests/privacy/provider_test.php
@@ -37,7 +37,7 @@ require_once($CFG->dirroot . '/plagiarism/turnitinsim/tests/turnitinsim_generato
 /**
  * Privacy provider tests.
  */
-class plagiarism_turnitinsim_privacy_provider_testcase extends advanced_testcase {
+class provider_test extends advanced_testcase {
 
     protected $turnitinsim_generator;
     protected $submission;
@@ -46,7 +46,7 @@ class plagiarism_turnitinsim_privacy_provider_testcase extends advanced_testcase
      * Setup method that runs before each test.
      */
     public function setUp(): void {
-        $this->turnitinsim_generator = new turnitinsim_generator();
+        $this->turnitinsim_generator = new turnitinsim_generator('turnitinsim_generator');
         $this->submission = $this->turnitinsim_generator->create_submission();
     }
 

--- a/tests/utilities/handle_deprecation_test.php
+++ b/tests/utilities/handle_deprecation_test.php
@@ -31,7 +31,7 @@ require_once($CFG->dirroot . '/plagiarism/turnitinsim/utilities/handle_deprecati
 /**
  * Tests for handle_deprecations methods.
  */
-class plagiarism_turnitinsim_handle_deprecation_testcase extends advanced_testcase {
+class handle_deprecation_test extends advanced_testcase {
 
     /**
      * Test the enable_plugin and plugin_enabled methods.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Mostly test and tooling changes; production edits are small defensive checks and display formatting in plagiarism links, with limited blast radius.
> 
> **Overview**
> Modernizes the plugin’s PHPUnit setup and aligns tests with current Moodle/PHPUnit conventions, alongside a few small runtime hardening and UI tweaks.
> 
> Adds **`phpunit.xml`** (plugin test suite, excludes behat) and ignores **`.phpunit.result.cache`** instead of **`tests/behat`**. Test classes are renamed from `*_testcase` to shorter names (e.g. `assign_class_test`), mocks use **`onlyMethods`** instead of **`setMethods`**, and several tests declare **`private`/`protected` properties** used in `setUp` or helpers. **`turnitinsim_generator`** is constructed with a name argument where needed; EULA status tests assert against **`turnitin_eula_url`** from config rather than a hardcoded query string.
> 
> **Production changes:** **`get_latest_version()`** falls back to **`en-US`** when language is unset; **`test_connection()`** only decodes the webhook response when **`send_request`** returns a value; **`get_links()`** returns an empty string when inactive, wraps empty plagiarism records in the links container, and appends **`%`** to displayed similarity scores.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7316dfcba4b2f5734302590d8902678d6c9ce9bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->