### PR TITLE
INT-25073 Fix saving plugin defaults

### DIFF
--- a/classes/settings.class.php
+++ b/classes/settings.class.php
@@ -222,7 +222,8 @@ class plagiarism_turnitinsim_settings {
             $DB->update_record('plagiarism_turnitinsim_mod', $settings);
         } else {
             // Inserts only happen on activity creation, so if turnitinenabled is false - don't insert.
-            if ($settings->turnitinenabled) {
+            // Override if saving defaults (we know we're on the defaults page when cm == 0)
+            if ($settings->cm == 0 || $settings->turnitinenabled) {
                 $DB->insert_record('plagiarism_turnitinsim_mod', $settings);
             }
         }


### PR DESCRIPTION
Currently there's a check in the code that will only allow saving plugin settings if the topmost setting, enable turnitin, is set to true.
This causes issues on the defaults page, since we reuse the same code for saving settings in both places.
This PR tells the plugin to save settings if the save function is running either on the defaults page, as indicated by cm==0, or if the plugin is enabled for the current course module

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single conditional change in settings persistence; activity-level behavior is unchanged except defaults can now be saved with Turnitin off.
> 
> **Overview**
> **Fixes plugin default settings not persisting** when “Enable Turnitin” is unchecked on the defaults page.
> 
> `save_module_settings` shared the same insert guard as per-activity saves: new `plagiarism_turnitinsim_mod` rows were only inserted when `turnitinenabled` was true. The defaults form always uses `coursemodule = 0`, so saving defaults with Turnitin disabled never created a row.
> 
> The insert condition is now **`cm == 0` OR `turnitinenabled`**, so defaults always persist while activity creation still skips inserts when the plugin is off for a new module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebbeb80faa24a2d89a8021ffac9bed5c91fee013. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->