### PR TITLE
Merge to QA

### DIFF
--- a/classes/settings.class.php
+++ b/classes/settings.class.php
@@ -222,7 +222,8 @@ class plagiarism_turnitinsim_settings {
             $DB->update_record('plagiarism_turnitinsim_mod', $settings);
         } else {
             // Inserts only happen on activity creation, so if turnitinenabled is false - don't insert.
-            if ($settings->turnitinenabled) {
+            // Override if saving defaults (we know we're on the defaults page when cm == 0)
+            if ($settings->cm == 0 || $settings->turnitinenabled) {
                 $DB->insert_record('plagiarism_turnitinsim_mod', $settings);
             }
         }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single conditional change in settings persistence with no auth or external API impact; behavior change is limited to when default rows are created.
> 
> **Overview**
> **Fixes saving site-wide Turnitin defaults** when Turnitin is left disabled on the plugin defaults form.
> 
> `save_module_settings` used to **skip** inserting into `plagiarism_turnitinsim_mod` unless `turnitinenabled` was on, which blocked persisting default exclude/index/report/access options on first save (`cm == 0`). Inserts now run when **`cm == 0`** (defaults page) **or** when Turnitin is enabled on a new activity, matching the existing update path for records that already exist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84f17289f69ee2369ad7b04e0583ab75387f1e67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->