### PR TITLE
INT-25163 Release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+### Date:       2026-July-29
+### Release:    v2026072901
+
+---
+
+#### Fixed Incorrect Similarity Report After Replacing Group Submission
+We fixed a bug where replacing a group submission with a file of the same name would incorrectly display the previous submission's Similarity Report.
+
+#### Fixed Plugin Settings Not Saving Correctly
+We fixed a bug where plugin settings were not saving correctly.
+
+#### UI Fixes
+UI fixes.
+
+---
+
 ### Date:       2025-November-13
 ### Release:    v2025111301
 

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2026012201;
+$plugin->version = 2026072901;
 $plugin->release = "v1.2";
 $plugin->requires = 2022112800;
 $plugin->component = 'plagiarism_turnitinsim';


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation and version metadata only; no application logic changes in this PR.
> 
> **Overview**
> This PR **releases v2026072901** for the Turnitin Integrity Moodle plugin by bumping `$plugin->version` in `version.php` from `2026012201` to `2026072901` and adding a **2026-July-29** entry at the top of `CHANGELOG.md`.
> 
> The changelog documents fixes that are **not part of this diff** (release notes only): incorrect Similarity Report when replacing a group submission with a same-named file, plugin settings not saving correctly, and miscellaneous UI fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5efc54cb2b1102e82b878bf66b94a215bd9f5377. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->