### PR TITLE
INT-24980 Release to QA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+### Date:       2026-July-29
+### Release:    v2026072901
+
+---
+
+#### Fixed Incorrect Similarity Report After Replacing Group Submission
+We fixed a bug where replacing a group submission with a file of the same name would incorrectly display the previous submission's Similarity Report.
+
+#### Fixed Plugin Settings Not Saving Correctly
+We fixed a bug where plugin settings were not saving correctly.
+
+#### UI Fixes
+UI fixes.
+
+---
+
 ### Date:       2025-November-13
 ### Release:    v2025111301
 

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2026012201;
+$plugin->version = 2026072901;
 $plugin->release = "v1.2";
 $plugin->requires = 2022112800;
 $plugin->component = 'plagiarism_turnitinsim';

--- a/version.php
+++ b/version.php
@@ -27,6 +27,6 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->version = 2026072901;
 $plugin->release = "v1.2";
-$plugin->requires = 2022112800;
+$plugin->requires = 2024100700;
 $plugin->component = 'plagiarism_turnitinsim';
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are limited to version metadata and release notes; the Moodle minimum version bump may affect sites on older Moodle builds.
> 
> **Overview**
> This PR **releases v2026072901** to QA by updating plugin metadata and the changelog—no application code appears in the diff.
> 
> **`version.php`** bumps the plugin version from `2026012201` to `2026072901` and raises the minimum Moodle requirement from `2022112800` to `2024100700`.
> 
> **`CHANGELOG.md`** documents the release with fixes for incorrect Similarity Reports after replacing a group submission with the same filename, plugin settings not saving correctly, and miscellaneous UI fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d498816f722f6e02f372ffdfd0fb5a24602567eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->