### PR TITLE
INT-25163 Bump required version

### DIFF
--- a/version.php
+++ b/version.php
@@ -27,6 +27,6 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->version = 2026072901;
 $plugin->release = "v1.2";
-$plugin->requires = 2022112800;
+$plugin->requires = 2024100700;
 $plugin->component = 'plagiarism_turnitinsim';
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single metadata change in version.php with no runtime code impact; risk is limited to sites on Moodle 4.1–4.4 no longer being able to install or upgrade this plugin without upgrading Moodle first.
> 
> **Overview**
> Raises the **minimum Moodle core version** for the Turnitin Integrity plagiarism plugin from **4.1** (`2022112800`) to **4.5** (`2024100700`) in `version.php`.
> 
> No plugin logic, APIs, or features change—only the declared `$plugin->requires` value so installs on Moodle older than 4.5 are blocked at upgrade/check time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05a1163a4343af68ebe4a57fc9557b8066a7838a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->